### PR TITLE
__PVZCLASS_LOCALEXECUTE 宏彻底替代 Memory::LocalExecute

### DIFF
--- a/pvzclass/Classes/Memory.cpp
+++ b/pvzclass/Classes/Memory.cpp
@@ -37,18 +37,16 @@ BOOL PVZ::Memory::AllAccessRemote(int address)
 	return VirtualProtectEx(hProcess, (LPVOID)address, PAGE_SIZE, PAGE_EXECUTE_READWRITE, &op);
 }
 
-int PVZ::Memory::AllocMemory(int pages, int size)
+int PVZ::Memory::AllocMemoryLocal(int pages, int size)
 {
-	if (localExecute)
-	{
-		BYTE* page = new BYTE[PAGE_SIZE * pages + size];
-		AllAccessLocal((int)page);
-		return (int)page;
-	}
-	else
-	{
-		return (int)VirtualAllocEx(hProcess, 0, PAGE_SIZE * pages + size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
-	}
+	BYTE* page = new BYTE[PAGE_SIZE * pages + size];
+	AllAccessLocal((int)page);
+	return (int)page;
+}
+
+int PVZ::Memory::AllocMemoryRemote(int pages, int size)
+{
+	return (int)VirtualAllocEx(hProcess, 0, PAGE_SIZE * pages + size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 }
 
 void PVZ::Memory::CreateThread(int address)

--- a/pvzclass/Classes/Memory.cpp
+++ b/pvzclass/Classes/Memory.cpp
@@ -73,29 +73,27 @@ void PVZ::Memory::FreeMemoryRemote(int address)
 	VirtualFreeEx(hProcess, (LPVOID)address, 0, MEM_RELEASE);
 }
 
-int PVZ::Memory::Execute(byte asmCode[], int length)
+int PVZ::Memory::ExecuteLocal(byte asmCode[], int length)
 {
-	if (localExecute)
-	{
-		byte* code = new byte[length + 2];
-		code[0] = PUSHAD;
-		memcpy(code + 1, asmCode, length);
-		code[length] = POPAD;
-		code[length + 1] = RET;
-		void (*func)() = (void (*)())code;
-		func();
-		return ReadMemory<int>(Variable);
-	}
-	else
-	{
-		int Address = AllocMemory();
-		WriteArray<byte>(Address, asmCode, length);
-		if (!immediateExecute) WaitPVZ();
-		CreateThread(Address);
-		if (!immediateExecute) ResumePVZ();
-		FreeMemory(Address);
-		return ReadMemory<int>(Variable);
-	}
+	byte* code = new byte[length + 2];
+	code[0] = PUSHAD;
+	memcpy(code + 1, asmCode, length);
+	code[length] = POPAD;
+	code[length + 1] = RET;
+	void (*func)() = (void (*)())code;
+	func();
+	return ReadMemory<int>(Variable);
+}
+
+int PVZ::Memory::ExecuteRemote(byte asmCode[], int length)
+{
+	int Address = AllocMemory();
+	WriteArray<byte>(Address, asmCode, length);
+	if (!immediateExecute) WaitPVZ();
+	CreateThread(Address);
+	if (!immediateExecute) ResumePVZ();
+	FreeMemory(Address);
+	return ReadMemory<int>(Variable);
 }
 
 void PVZ::Memory::WaitPVZ()

--- a/pvzclass/Classes/Memory.cpp
+++ b/pvzclass/Classes/Memory.cpp
@@ -63,16 +63,14 @@ void PVZ::Memory::CreateThread(int address)
 	}
 }
 
-void PVZ::Memory::FreeMemory(int address)
+void PVZ::Memory::FreeMemoryLocal(int address)
 {
-	if (localExecute)
-	{
-		delete (void*)address;
-	}
-	else
-	{
-		VirtualFreeEx(hProcess, (LPVOID)address, 0, MEM_RELEASE);
-	}
+	delete (void*)address;
+}
+
+void PVZ::Memory::FreeMemoryRemote(int address)
+{
+	VirtualFreeEx(hProcess, (LPVOID)address, 0, MEM_RELEASE);
 }
 
 int PVZ::Memory::Execute(byte asmCode[], int length)

--- a/pvzclass/Classes/Memory.cpp
+++ b/pvzclass/Classes/Memory.cpp
@@ -7,7 +7,6 @@ DWORD PVZ::Memory::mainThreadId = 0;
 int PVZ::Memory::Variable = 0;
 HWND PVZ::Memory::mainwindowhandle = NULL;
 bool PVZ::Memory::immediateExecute = false;
-bool PVZ::Memory::localExecute = false;
 int PVZ::Memory::DLLAddress = 0;
 
 int PVZ::Memory::ReadPointer(int baseaddress, int offset)

--- a/pvzclass/Classes/Memory.cpp
+++ b/pvzclass/Classes/Memory.cpp
@@ -25,17 +25,16 @@ int PVZ::Memory::ReadPointer(int baseaddress, int offset, int offset1, int offse
 	return ReadMemory<int>(ReadPointer(baseaddress, offset, offset1) + offset2);
 }
 
-BOOL PVZ::Memory::AllAccess(int address)
+BOOL PVZ::Memory::AllAccessLocal(int address)
 {
 	DWORD op = PAGE_READONLY;
-	if (localExecute)
-	{
-		return VirtualProtect((LPVOID)address, PAGE_SIZE, PAGE_EXECUTE_READWRITE, &op);
-	}
-	else
-	{
-		return VirtualProtectEx(hProcess, (LPVOID)address, PAGE_SIZE, PAGE_EXECUTE_READWRITE, &op);
-	}
+	return VirtualProtect((LPVOID)address, PAGE_SIZE, PAGE_EXECUTE_READWRITE, &op);
+}
+
+BOOL PVZ::Memory::AllAccessRemote(int address)
+{
+	DWORD op = PAGE_READONLY;
+	return VirtualProtectEx(hProcess, (LPVOID)address, PAGE_SIZE, PAGE_EXECUTE_READWRITE, &op);
 }
 
 int PVZ::Memory::AllocMemory(int pages, int size)
@@ -43,7 +42,7 @@ int PVZ::Memory::AllocMemory(int pages, int size)
 	if (localExecute)
 	{
 		BYTE* page = new BYTE[PAGE_SIZE * pages + size];
-		AllAccess((int)page);
+		AllAccessLocal((int)page);
 		return (int)page;
 	}
 	else

--- a/pvzclass/PVZ.cpp
+++ b/pvzclass/PVZ.cpp
@@ -45,7 +45,6 @@ namespace PVZ
 		Memory::hThread = OpenThread(THREAD_ALL_ACCESS, true, Memory::mainThreadId);
 
 		Memory::immediateExecute = false;
-		Memory::localExecute = false;
 		SETARG(__asm__Execute, 2) = Memory::Variable + 0x540;
 		SETARG(__asm__Execute, 9) = Memory::Variable + 0x530;
 		SETARG(__asm__Execute, 18) = Memory::Variable + 0x540;

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -169,7 +169,8 @@ namespace PVZ
 		static int ReadPointer(int baseaddress, int offset, int offset1, int offset2);
 		static BOOL AllAccessLocal(int address);
 		static BOOL AllAccessRemote(int address);
-		static int AllocMemory(int pages = 1, int size = 0);
+		static int AllocMemoryLocal(int pages = 1, int size = 0);
+		static int AllocMemoryRemote(int pages = 1, int size = 0);
 		static void CreateThread(int address);
 		static void FreeMemory(int address);
 		static int Execute(byte asmcode[], int lengrh);
@@ -184,11 +185,15 @@ namespace PVZ
 #define ReadArray ReadArrayLocal
 #define WriteMemory WriteMemoryLocal
 #define WriteArray WriteArrayLocal
+#define AllAccess AllAccessLocal
+#define AllocMemory AllocMemoryLocal
 #else
 #define ReadMemory ReadMemoryRemote
 #define ReadArray ReadArrayRemote
 #define WriteMemory WriteMemoryRemote
 #define WriteArray WriteArrayRemote
+#define AllAccess AllAccessRemote
+#define AllocMemory AllocMemoryRemote
 #endif
 	};
 

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -172,7 +172,8 @@ namespace PVZ
 		static int AllocMemoryLocal(int pages = 1, int size = 0);
 		static int AllocMemoryRemote(int pages = 1, int size = 0);
 		static void CreateThread(int address);
-		static void FreeMemory(int address);
+		static void FreeMemoryLocal(int address);
+		static void FreeMemoryRemote(int address);
 		static int Execute(byte asmcode[], int lengrh);
 		static bool InjectDll(const char* dllname);
 		static int GetProcAddress(const char* procname);
@@ -187,6 +188,7 @@ namespace PVZ
 #define WriteArray WriteArrayLocal
 #define AllAccess AllAccessLocal
 #define AllocMemory AllocMemoryLocal
+#define FreeMemory FreeMemoryLocal
 #else
 #define ReadMemory ReadMemoryRemote
 #define ReadArray ReadArrayRemote
@@ -194,6 +196,7 @@ namespace PVZ
 #define WriteArray WriteArrayRemote
 #define AllAccess AllAccessRemote
 #define AllocMemory AllocMemoryRemote
+#define FreeMemory FreeMemoryRemote
 #endif
 	};
 

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -167,7 +167,8 @@ namespace PVZ
 		static int ReadPointer(int baseaddress, int offset);
 		static int ReadPointer(int baseaddress, int offset, int offset1);
 		static int ReadPointer(int baseaddress, int offset, int offset1, int offset2);
-		static BOOL AllAccess(int address);
+		static BOOL AllAccessLocal(int address);
+		static BOOL AllAccessRemote(int address);
 		static int AllocMemory(int pages = 1, int size = 0);
 		static void CreateThread(int address);
 		static void FreeMemory(int address);

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -104,8 +104,6 @@ namespace PVZ
 		static HWND mainwindowhandle;
 		// 如果为true，则不会等待PVZ进程，立即执行远程代码
 		static bool immediateExecute;
-		// 如果为true，则在当前线程执行代码，在dll中设置为true
-		static bool localExecute;
 		static int DLLAddress;
 		
 		template <class T>
@@ -182,6 +180,7 @@ namespace PVZ
 		static void WaitPVZ(); // 等待PVZ到达更新前
 		static void ResumePVZ(); // 恢复PVZ
 
+// 如果为true，则在当前线程执行代码，在dll中设置为true
 #ifdef __PVZCLASS_LOCALEXECUTE
 #define ReadMemory ReadMemoryLocal
 #define ReadArray ReadArrayLocal

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -174,7 +174,8 @@ namespace PVZ
 		static void CreateThread(int address);
 		static void FreeMemoryLocal(int address);
 		static void FreeMemoryRemote(int address);
-		static int Execute(byte asmcode[], int lengrh);
+		static int ExecuteLocal(byte asmcode[], int lengrh);
+		static int ExecuteRemote(byte asmcode[], int lengrh);
 		static bool InjectDll(const char* dllname);
 		static int GetProcAddress(const char* procname);
 		static int InvokeDllProc(const char* procname);
@@ -189,6 +190,7 @@ namespace PVZ
 #define AllAccess AllAccessLocal
 #define AllocMemory AllocMemoryLocal
 #define FreeMemory FreeMemoryLocal
+#define Execute ExecuteLocal
 #else
 #define ReadMemory ReadMemoryRemote
 #define ReadArray ReadArrayRemote
@@ -197,6 +199,7 @@ namespace PVZ
 #define AllAccess AllAccessRemote
 #define AllocMemory AllocMemoryRemote
 #define FreeMemory FreeMemoryRemote
+#define Execute ExecuteRemote
 #endif
 	};
 

--- a/pvzdll/pch.cpp
+++ b/pvzdll/pch.cpp
@@ -6,7 +6,6 @@
 
 void init()
 {
-	PVZ::Memory::localExecute = true;
 	PVZ::Memory::mainwindowhandle = PVZ::Memory::ReadMemory<HWND>(PVZ_BASE + 0x350);
 	PVZ::Memory::Variable = PVZ::Memory::AllocMemory(4);
 }


### PR DESCRIPTION
现在要使用 Local 版本的函数，需要在 `#include "pvzclass.h"` 前添加 `__PVZCLASS_LOCALEXECUTE`。
至于 `PVZ::Memory::LocalExecute` 嘛，它被彻底驱逐了。

明天我就会合并这条 PR，有意见和建议的欢迎在下面回复。