### PR TITLE
ResourceManager 完善

### DIFF
--- a/pvzclass/AsmBuilder.hpp
+++ b/pvzclass/AsmBuilder.hpp
@@ -104,6 +104,12 @@ public:
 		return *this;
 	}
 
+	// 添加 PUSH 指令，参数强制为 32 位。
+	AsmBuilder& push_imm32(uint32_t value)
+	{
+		return add_byte(0x68).add_dword(value);
+	}
+
 	// 添加 PUSH 指令
 	AsmBuilder& push_reg(uint8_t reg)
 	{

--- a/pvzclass/Classes.hpp
+++ b/pvzclass/Classes.hpp
@@ -1,3 +1,5 @@
 #pragma once
 #include "Classes/ChallengeScreen.hpp"
 #include "Classes/TodParticleSystem.hpp"
+
+#include "Classes/ResourceManager.hpp"

--- a/pvzclass/Classes/ResourceManager.cpp
+++ b/pvzclass/Classes/ResourceManager.cpp
@@ -39,9 +39,13 @@ bool PVZ::ResourceManager::ParseResourcesFile(const char* fileName)
 		.push(0)
 		.push_reg(REG_ESP)
 		.invoke(0x404450)
+
 		.mov_reg_reg(REG_ECX, REG_ESP)
 		.push_imm32(this->GetBaseAddress())
 		.invoke(0x5B6A20)
+		.xor_reg_reg(REG_EAX, REG_EAX)
+		.mov_mem_reg(PVZ::Memory::Variable, REG_EAX)
+
 		.mov_reg_reg(REG_ECX, REG_ESP)
 		.invoke(0x404420)
 		.ret();
@@ -58,11 +62,36 @@ bool PVZ::ResourceManager::TodLoadResources(const char* groupName)
 		.push(0)
 		.push_reg(REG_ESP)
 		.invoke(0x404450)
+
 		.push_reg(REG_ESP)
 		.invoke(0x513120)
+		.xor_reg_reg(REG_EAX, REG_EAX)
+		.mov_mem_reg(PVZ::Memory::Variable, REG_EAX)
+
 		.mov_reg_reg(REG_ECX, REG_ESP)
 		.invoke(0x404420)
 		.ret();
 
 	return PVZ::Memory::Execute(TodLoadResources_builder);
+}
+
+AsmBuilder GetSoundThrow_builder = AsmBuilder(128);
+PVZ::SoundID PVZ::ResourceManager::GetSoundThrow(const char* soundName)
+{
+	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, soundName, std::strlen(soundName) + 1);
+	GetSoundThrow_builder.clear()
+		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
+		.push(0)
+		.push_reg(REG_ESP)
+		.invoke(0x404450)
+
+		.push_reg(REG_ESP)
+		.invoke(0x5B81F0)
+		.mov_mem_reg(PVZ::Memory::Variable, REG_EAX)
+
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.invoke(0x404420)
+		.ret();
+
+	return (PVZ::SoundID)PVZ::Memory::Execute(GetSoundThrow_builder);
 }

--- a/pvzclass/Classes/ResourceManager.cpp
+++ b/pvzclass/Classes/ResourceManager.cpp
@@ -24,7 +24,27 @@ bool PVZ::ResourceManager::ParseResourcesFile(const char* fileName)
 		.mov_reg_reg(REG_ECX, REG_ESP)
 		.push_imm32(this->GetBaseAddress())
 		.invoke(0x5B6A20)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.invoke(0x404420)
 		.ret();
 
 	return PVZ::Memory::Execute(ParseResourcesFile_builder);
+}
+
+AsmBuilder TodLoadResources_builder = AsmBuilder(128);
+bool PVZ::ResourceManager::TodLoadResources(const char* groupName)
+{
+	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, groupName, std::strlen(groupName) + 1);
+	TodLoadResources_builder.clear()
+		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
+		.push(0)
+		.push_reg(REG_ESP)
+		.invoke(0x404450)
+		.push_reg(REG_ESP)
+		.invoke(0x513120)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.invoke(0x404420)
+		.ret();
+
+	return PVZ::Memory::Execute(TodLoadResources_builder);
 }

--- a/pvzclass/Classes/ResourceManager.cpp
+++ b/pvzclass/Classes/ResourceManager.cpp
@@ -11,3 +11,20 @@ namespace PVZ
 		return PVZApp(Memory::ReadMemory<DWORD>(BaseAddress + 0x58));
 	}
 }
+
+AsmBuilder ParseResourcesFile_builder = AsmBuilder(128);
+bool PVZ::ResourceManager::ParseResourcesFile(const char* fileName)
+{
+	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, fileName, std::strlen(fileName) + 1);
+	ParseResourcesFile_builder.clear()
+		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
+		.push(0)
+		.push_reg(REG_ESP)
+		.invoke(0x404450)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.push_imm32(this->GetBaseAddress())
+		.invoke(0x5B6A20)
+		.ret();
+
+	return PVZ::Memory::Execute(ParseResourcesFile_builder);
+}

--- a/pvzclass/Classes/ResourceManager.cpp
+++ b/pvzclass/Classes/ResourceManager.cpp
@@ -17,9 +17,9 @@ void PVZ::ResourceManager::AddPAKFile(const char* fileName)
 {
 	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, fileName, std::strlen(fileName) + 1);
 	AddPAKFile_builder.clear()
-		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
 		.push(0)
-		.push_reg(REG_ESP)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.push_imm32(PVZ::Memory::Variable + 100)
 		.invoke(0x404450)
 		.mov_reg_reg(REG_ECX, REG_ESP)
 		.invoke(0x5D7D90)
@@ -35,9 +35,9 @@ bool PVZ::ResourceManager::ParseResourcesFile(const char* fileName)
 {
 	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, fileName, std::strlen(fileName) + 1);
 	ParseResourcesFile_builder.clear()
-		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
 		.push(0)
-		.push_reg(REG_ESP)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.push_imm32(PVZ::Memory::Variable + 100)
 		.invoke(0x404450)
 
 		.mov_reg_reg(REG_ECX, REG_ESP)
@@ -58,9 +58,9 @@ bool PVZ::ResourceManager::TodLoadResources(const char* groupName)
 {
 	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, groupName, std::strlen(groupName) + 1);
 	TodLoadResources_builder.clear()
-		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
 		.push(0)
-		.push_reg(REG_ESP)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.push_imm32(PVZ::Memory::Variable + 100)
 		.invoke(0x404450)
 
 		.push_reg(REG_ESP)
@@ -80,9 +80,9 @@ PVZ::SoundID PVZ::ResourceManager::GetSoundThrow(const char* soundName)
 {
 	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, soundName, std::strlen(soundName) + 1);
 	GetSoundThrow_builder.clear()
-		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
 		.push(0)
-		.push_reg(REG_ESP)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.push_imm32(PVZ::Memory::Variable + 100)
 		.invoke(0x404450)
 
 		.push_reg(REG_ESP)
@@ -94,4 +94,33 @@ PVZ::SoundID PVZ::ResourceManager::GetSoundThrow(const char* soundName)
 		.ret();
 
 	return (PVZ::SoundID)PVZ::Memory::Execute(GetSoundThrow_builder);
+}
+
+AsmBuilder GetImage_builder = AsmBuilder(128);
+PVZ::Image PVZ::ResourceManager::GetImage(const char* imageName)
+{
+	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, imageName, std::strlen(imageName) + 1);
+	GetImage_builder.clear()
+		.push(0)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.push_imm32(PVZ::Memory::Variable + 100)
+		.invoke(0x404450)
+
+		.push_reg(REG_ESP)
+		.push_imm32(PVZ::Memory::Variable)
+		.mov_reg_imm(REG_ECX, this->GetBaseAddress())
+		.invoke(0x5B8000)
+
+		.mov_reg_reg(REG_ECX, REG_EAX)
+		.invoke(0x59A980)
+		.mov_mem_reg(PVZ::Memory::Variable, REG_EAX)
+
+		.mov_reg_reg(REG_ESI, REG_ECX)
+		.invoke(0x59A8C0)
+
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.invoke(0x404420)
+		.ret();
+
+	return (PVZ::SoundID)PVZ::Memory::Execute(GetImage_builder);
 }

--- a/pvzclass/Classes/ResourceManager.cpp
+++ b/pvzclass/Classes/ResourceManager.cpp
@@ -12,6 +12,24 @@ namespace PVZ
 	}
 }
 
+AsmBuilder AddPAKFile_builder = AsmBuilder(128);
+void PVZ::ResourceManager::AddPAKFile(const char* fileName)
+{
+	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, fileName, std::strlen(fileName) + 1);
+	AddPAKFile_builder.clear()
+		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable + 100)
+		.push(0)
+		.push_reg(REG_ESP)
+		.invoke(0x404450)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.invoke(0x5D7D90)
+		.mov_reg_reg(REG_ECX, REG_ESP)
+		.invoke(0x404420)
+		.ret();
+
+	PVZ::Memory::Execute(AddPAKFile_builder);
+}
+
 AsmBuilder ParseResourcesFile_builder = AsmBuilder(128);
 bool PVZ::ResourceManager::ParseResourcesFile(const char* fileName)
 {

--- a/pvzclass/Classes/ResourceManager.hpp
+++ b/pvzclass/Classes/ResourceManager.hpp
@@ -11,6 +11,9 @@ namespace PVZ
 	public:
 		ResourceManager(int address) : BaseClass(address) {};
 		PVZApp GetPVZApp();
+		//@brief 加载指定资源包文件。
+		//@param fileName 文件名
+		void AddPAKFile(const char* fileName);
 		//@brief 尝试解析指定的资源描述文件。
 		//@param fileName 文件名
 		//@return 是否解析成功。

--- a/pvzclass/Classes/ResourceManager.hpp
+++ b/pvzclass/Classes/ResourceManager.hpp
@@ -22,6 +22,10 @@ namespace PVZ
 		//@param groupName 资源组名称。
 		//@return 是否加载成功。
 		bool TodLoadResources(const char* groupName);
+		//@brief 获取指定音效的编号。
+		//@param soundName 音效在资源描述文件中的名称。
+		//@return 是否加载成功。
+		SoundID GetSoundThrow(const char* soundName);
 	};
 	ResourceManager GetResourceManager();
 }

--- a/pvzclass/Classes/ResourceManager.hpp
+++ b/pvzclass/Classes/ResourceManager.hpp
@@ -24,8 +24,12 @@ namespace PVZ
 		bool TodLoadResources(const char* groupName);
 		//@brief 获取指定音效的编号。
 		//@param soundName 音效在资源描述文件中的名称。
-		//@return 是否加载成功。
+		//@return 音效编号。
 		SoundID GetSoundThrow(const char* soundName);
+		//@brief 获取指定的图片。
+		//@param imageName 图片在资源描述文件中的名称。
+		//@return 对应的图片。
+		Image GetImage(const char* imageName);
 	};
 	ResourceManager GetResourceManager();
 }

--- a/pvzclass/Classes/ResourceManager.hpp
+++ b/pvzclass/Classes/ResourceManager.hpp
@@ -11,6 +11,10 @@ namespace PVZ
 	public:
 		ResourceManager(int address) : BaseClass(address) {};
 		PVZApp GetPVZApp();
+		//@brief 尝试解析指定的资源描述文件。
+		//@param fileName 文件名
+		//@return 是否解析成功。
+		bool ParseResourcesFile(const char* fileName);
 	};
 	ResourceManager GetResourceManager();
 }

--- a/pvzclass/Classes/ResourceManager.hpp
+++ b/pvzclass/Classes/ResourceManager.hpp
@@ -15,6 +15,10 @@ namespace PVZ
 		//@param fileName 文件名
 		//@return 是否解析成功。
 		bool ParseResourcesFile(const char* fileName);
+		//@brief 加载指定的资源组。
+		//@param groupName 资源组名称。
+		//@return 是否加载成功。
+		bool TodLoadResources(const char* groupName);
 	};
 	ResourceManager GetResourceManager();
 }

--- a/pvzclass/Enums/UpperSoundType.h
+++ b/pvzclass/Enums/UpperSoundType.h
@@ -175,3 +175,8 @@ namespace UpperSoundType
 	extern const char* ToString(UpperSoundType sound);
 
 }
+
+namespace PVZ
+{
+	using SoundID = UpperSoundType::UpperSoundType;
+}

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -46,6 +46,9 @@
 #include "ChallengeUpdateEvent.hpp"
 #include "CoinMouseDownEvent.hpp"
 #include "GriditemDieEvent.hpp"
+
+#include "ParseResourceEvent.hpp"
+
 #include "PlantAddProjectileEvent.hpp"
 #include "PlantDieLowHealthEvent.hpp"
 #include "PlantDoSpecialEvent.hpp"

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -47,6 +47,7 @@
 #include "CoinMouseDownEvent.hpp"
 #include "GriditemDieEvent.hpp"
 
+#include "ExtractResourceEvent.hpp"
 #include "ParseResourceEvent.hpp"
 
 #include "PlantAddProjectileEvent.hpp"

--- a/pvzclass/Events/ExtractResourceEvent.hpp
+++ b/pvzclass/Events/ExtractResourceEvent.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include "DLLEvent.h"
+
+// 提取资源事件。
+// 时机发生在 resources.xml 解析成功后。
+// @param 触发事件的 ResourceManager，读取的资源组名称（string& 形式）
+// @return 若为正数，则读取成功；若为 0，则读取失败；若为负数，结算原版过程。
+class ExtractResourceEvent : public DLLEvent
+{
+public:
+	ExtractResourceEvent();
+};
+
+ExtractResourceEvent::ExtractResourceEvent()
+{
+	int procAddress = PVZ::Memory::GetProcAddress("onExtractResource");
+	hookAddress = 0x474700;
+	rawlen = 5;
+	BYTE code[] =
+	{
+		PUSH_PTR_ESP_ADD_V(0x28),
+		PUSH_PTR_ESP_ADD_V(0x28),
+		INVOKE(procAddress),
+		ADD_ESP(8),
+
+		TEST_EUX_EVX(REG_EAX, REG_EAX),
+		JS(17),
+		JE(9),
+
+		POPAD,
+		MOV_EAX(1),
+		RETN(8),
+
+		POPAD,
+		XOR_EUX_EVX(REG_EAX, REG_EAX),
+		RETN(8),
+	};
+	start(STRING(code));
+}

--- a/pvzclass/Events/ParseResourceEvent.hpp
+++ b/pvzclass/Events/ParseResourceEvent.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "DLLEvent.h"
+
+// 解析资源配置文件事件。
+// 时机发生在 resources.xml 解析成功后。
+// 无返回值
+class ParseResourceEvent : public DLLEvent
+{
+public:
+	ParseResourceEvent();
+};
+
+ParseResourceEvent::ParseResourceEvent()
+{
+	int procAddress = PVZ::Memory::GetProcAddress("onParseResource");
+	hookAddress = 0x451A0D;
+	rawlen = 7;
+	BYTE code[] =
+	{
+		INVOKE(procAddress),
+	};
+	start(STRING(code));
+}

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -272,6 +272,7 @@
     <ClInclude Include="Events\DialogDrawEvent.h" />
     <ClInclude Include="Events\DLLEvent.h" />
     <ClInclude Include="Events\Events.h" />
+    <ClInclude Include="Events\ExtractResourceEvent.hpp" />
     <ClInclude Include="Events\GriditemDieEvent.hpp" />
     <ClInclude Include="Events\GriditemUpdateEvent.hpp" />
     <ClInclude Include="Events\IZInitAfterBrainEvent.hpp" />

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -281,6 +281,7 @@
     <ClInclude Include="Events\LawnmowerStartEvent.hpp" />
     <ClInclude Include="Events\LawnmowerUpdateEvent.hpp" />
     <ClInclude Include="Events\NewGameEvent.h" />
+    <ClInclude Include="Events\ParseResourceEvent.hpp" />
     <ClInclude Include="Events\PlantAddProjectileEvent.hpp" />
     <ClInclude Include="Events\PlantDieLowHealthEvent.hpp" />
     <ClInclude Include="Events\PlantDoSpecialEvent.hpp" />

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -64,6 +64,9 @@
     <Filter Include="头文件\Events\Challenge\Beghouled">
       <UniqueIdentifier>{65db0b32-c981-4a4f-9dda-b600df1b32ce}</UniqueIdentifier>
     </Filter>
+    <Filter Include="头文件\Events\Resource">
+      <UniqueIdentifier>{e097e27d-895f-4d97-aaf9-e3461a9e61ad}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PVZ.cpp">
@@ -715,6 +718,9 @@
     </ClInclude>
     <ClInclude Include="Classes\TodParticleSystem.hpp">
       <Filter>头文件\Classes</Filter>
+    </ClInclude>
+    <ClInclude Include="Events\ParseResourceEvent.hpp">
+      <Filter>头文件\Events\Resource</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -722,5 +722,8 @@
     <ClInclude Include="Events\ParseResourceEvent.hpp">
       <Filter>头文件\Events\Resource</Filter>
     </ClInclude>
+    <ClInclude Include="Events\ExtractResourceEvent.hpp">
+      <Filter>头文件\Events\Resource</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- 添加了 `PVZ::SoundID`，作为原 `UpperSoundID::UpperSoundID` 的别名。
- `ResourceManager.hpp` 现在会被 `Classes.hpp` 导入了。
- 添加了若干新函数，可让 pvzclass 访问 PVZ 本体的资源相关接口。
- 添加了 `ExtractResourceEvent` 和 `ParseResourceEvent`，可以为调用部分函数提供合适的时机。