### PR TITLE
若干漏洞修复

### DIFF
--- a/pvzclass/Classes/Challenge.cpp
+++ b/pvzclass/Classes/Challenge.cpp
@@ -5,11 +5,6 @@ PVZ::Challenge::Challenge(int address)
 	BaseAddress = Memory::ReadMemory<int>(address + 0x160);
 }
 
-int PVZ::Challenge::GetBaseAddress()
-{
-	return BaseAddress;
-}
-
 namespace PVZ
 {
 	bool Challenge::SetMemSize(int NewSize)

--- a/pvzclass/Classes/TodParticleSystem.cpp
+++ b/pvzclass/Classes/TodParticleSystem.cpp
@@ -93,7 +93,7 @@ std::vector<PVZ::TodParticleSystem> PVZ::GetAllParticleSystem()
 	DWORD holder = PVZ::Memory::ReadPointer(0x6A9EC0, 0x820, 0);
 	DWORD maxnum = Memory::ReadMemory<DWORD>(holder + 4), address = Memory::ReadMemory<DWORD>(holder);
 
-	for (int i = 0; i < maxnum; i++)
+	for (unsigned int i = 0; i < maxnum; i++)
 	{
 		PVZ::TodParticleSystem sys = PVZ::TodParticleSystem(address + i * 0x2C);
 		if (!sys.Dead)

--- a/pvzclass/Classes/ZenGarden.cpp
+++ b/pvzclass/Classes/ZenGarden.cpp
@@ -5,11 +5,6 @@ PVZ::ZenGarden::ZenGarden(int address)
 	BaseAddress = address;
 }
 
-int PVZ::ZenGarden::GetBaseAddress()
-{
-	return BaseAddress;
-}
-
 PVZ::Board PVZ::ZenGarden::GetBoard()
 {
 	return(PVZ::Board(Memory::ReadMemory<int>(BaseAddress + 4)));

--- a/pvzclass/Events/ExtractResourceEvent.hpp
+++ b/pvzclass/Events/ExtractResourceEvent.hpp
@@ -3,7 +3,7 @@
 
 // 提取资源事件。
 // 时机发生在 resources.xml 解析成功后。
-// @param 触发事件的 ResourceManager，读取的资源组名称（string& 形式）
+// @param 触发事件的 ResourceManager，读取的资源组名称（char* 形式）
 // @return 若为正数，则读取成功；若为 0，则读取失败；若为负数，结算原版过程。
 class ExtractResourceEvent : public DLLEvent
 {

--- a/pvzclass/Events/PlantEatenEvent.hpp
+++ b/pvzclass/Events/PlantEatenEvent.hpp
@@ -23,7 +23,7 @@ PlantEatenEvent::PlantEatenEvent()
 		ADD_ESP(8),
 
 		TEST_AL_AL,
-		JNZ(6),
+		JNZ(7),
 		POPAD,
 		PUSHDWORD(0x52FDEE),
 		RET

--- a/pvzclass/Events/PlantStolenEvent.hpp
+++ b/pvzclass/Events/PlantStolenEvent.hpp
@@ -3,7 +3,7 @@
 
 // 植物被偷走事件。
 // 无返回值
-// @param 依次为：触发事件的植物、啃食该植物的僵尸。
+// @param 依次为：触发事件的植物。
 class PlantStolenEvent : public DLLEvent
 {
 public:

--- a/pvzclass/PVZ.cpp
+++ b/pvzclass/PVZ.cpp
@@ -37,6 +37,7 @@ namespace PVZ
 
 	void InitPVZ(DWORD pid)
 	{
+		Memory::localExecute = false;
 		Memory::processId = pid;
 		Memory::hProcess = OpenProcess(PROCESS_ALL_ACCESS, 0, pid);
 		Memory::mainwindowhandle = Memory::ReadMemory<HWND>(PVZ_BASE + 0x350);

--- a/pvzmain/pvzmain.cpp
+++ b/pvzmain/pvzmain.cpp
@@ -3,7 +3,6 @@
 
 int main()
 {
-	PVZ::Memory::localExecute = false;
 	DWORD pid = ProcessOpener::Open();
 	if (!pid) return 1;
 	PVZ::InitPVZ(pid);


### PR DESCRIPTION
- 修复 `ExtractResourceEvent` 和 `PlantStolenEvent` 的实际参数与描述不一致的漏洞。
- 修复 `PlantEatenEvent` 会导致崩溃的漏洞。
- `pvzmain` 中设置 `localExecute` 的指令已被移至 `InitPVZ()`。