### PR TITLE
修复事件漏洞，调整版本号

### DIFF
--- a/pvzclass/Events/PlantInitAfterEvent.hpp
+++ b/pvzclass/Events/PlantInitAfterEvent.hpp
@@ -17,7 +17,7 @@ PlantInitAfterEvent::PlantInitAfterEvent()
 	rawlen = 7;
 	BYTE code[] =
 	{
-		PUSH_ESI,
+		PUSH_PTR_ESP_ADD_V(0x28),
 		INVOKE(procAddress),
 		ADD_ESP(4),
 	};

--- a/pvzclass/PVZ.cpp
+++ b/pvzclass/PVZ.cpp
@@ -78,7 +78,7 @@ void PVZ::InitPVZNoLock(DWORD pid)
 
 const char* PVZ::PVZutil::__get_Version()
 {
-	return "2.0.1.250301";
+	return "2.0.1+";
 }
 
 PVZVersion::PVZVersion PVZ::PVZutil::__get_GameVersion()


### PR DESCRIPTION
- 修复 `PlantInitAfterEvent` 会导致崩溃的漏洞。
- 调整了版本号，以避免最新版的漏洞被错认为是 2.0.1 版本漏洞的情况。