### PR TITLE
新增若干事件

### DIFF
--- a/pvzclass/Enums.h
+++ b/pvzclass/Enums.h
@@ -46,3 +46,4 @@
 #include "Enums/GameObjectType.hpp"
 #include "Enums/KeyCode.hpp"
 #include "Enums/StoreItem.hpp"
+#include "Enums/ZombieAttackType.hpp"

--- a/pvzclass/Enums/ZombieAttackType.hpp
+++ b/pvzclass/Enums/ZombieAttackType.hpp
@@ -1,0 +1,13 @@
+﻿#pragma once
+namespace ZombieAttackType
+{
+
+	enum ZombieAttackType
+	{
+		CHEW,
+		DRIVE_OVER,
+		VAULT,
+		LADDER,
+	};
+
+}

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -72,4 +72,5 @@
 #include "ZombieDropHeadEvent.hpp"
 #include "ZombieDropHeadParticleEvent.hpp"
 #include "ZombieDropLootEvent.hpp"
+#include "ZombieTargetPlantEvent.hpp"
 #include "ZombieEatSoundEvent.hpp"

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -62,6 +62,7 @@
 #include "PlantStolenEvent.hpp"
 #include "LawnmowerUpdateEvent.hpp"
 #include "SeedPacketMouseDownEvent.hpp"
+#include "SeedPacketUpdateEvent.hpp"
 #include "VaseBreakerPopulateEvent.hpp"
 #include "GriditemUpdateEvent.hpp"
 #include "ZombieInitAfterEvent.hpp"

--- a/pvzclass/Events/PlantAddProjectileEvent.hpp
+++ b/pvzclass/Events/PlantAddProjectileEvent.hpp
@@ -1,17 +1,17 @@
-#pragma once
+ï»¿#pragma once
 #include "DLLEvent.h"
 
-// Ö²Îï·¢Éä×Óµ¯ÊÂ¼ş¡£
-// Ê±»úÉÏÏÈÓÚ×Óµ¯Ë÷µĞÀàĞÍÉè¶¨ºÍÌØÊâ×Óµ¯ËÙ¶È¸Ä¶¯¡£
-// @param ÒÀ´ÎÎª£º´¥·¢ÊÂ¼şµÄÖ²Îï¡¢Éú³ÉµÄ×Óµ¯¡¢×Óµ¯Ä¿±ê½©Ê¬µÄ»ùÖ·¡£
-// @return ÊÇ·ñ¼ÌĞø½áËãÔ­°æµÄµ÷Õû¡£
-class PlantAddProjectileEvent : public DLLEvent
+// æ¤ç‰©å‘å°„å­å¼¹äº‹ä»¶ã€‚
+// æ—¶æœºä¸Šå…ˆäºå­å¼¹ç´¢æ•Œç±»å‹è®¾å®šå’Œç‰¹æ®Šå­å¼¹é€Ÿåº¦æ”¹åŠ¨ã€‚
+// @param ä¾æ¬¡ä¸ºï¼šè§¦å‘äº‹ä»¶çš„æ¤ç‰©ã€ç”Ÿæˆçš„å­å¼¹ã€å­å¼¹ç›®æ ‡åƒµå°¸çš„åŸºå€ã€‚
+// @return æ˜¯å¦ç»§ç»­ç»“ç®—åŸç‰ˆçš„è°ƒæ•´ã€‚
+class NormalPlantAddProjectileEvent : public DLLEvent
 {
 public:
-	PlantAddProjectileEvent();
+	NormalPlantAddProjectileEvent();
 };
 
-PlantAddProjectileEvent::PlantAddProjectileEvent()
+NormalPlantAddProjectileEvent::NormalPlantAddProjectileEvent()
 {
 	int procAddress = PVZ::Memory::GetProcAddress("onPlantAddProjectile");
 	hookAddress = 0x4672B5;

--- a/pvzclass/Events/PlantAddProjectileEvent.hpp
+++ b/pvzclass/Events/PlantAddProjectileEvent.hpp
@@ -5,6 +5,24 @@
 // 时机上先于子弹索敌类型设定和特殊子弹速度改动。
 // @param 依次为：触发事件的植物、生成的子弹、子弹目标僵尸的基址。
 // @return 是否继续结算原版的调整。
+class PlantAddProjectileEvent
+{
+private:
+	NormalPlantAddProjectileEvent* normal_event;
+	StarFruitAddProjectileEvent* star_event;
+public:
+	PlantAddProjectileEvent()
+	{
+		normal_event = new NormalPlantAddProjectileEvent("onPlantAddProjectile");
+		star_event = new StarFruitAddProjectileEvent("onPlantAddProjectile");
+	}
+	void end()
+	{
+		normal_event->end();
+		star_event->end();
+	}
+};
+
 class NormalPlantAddProjectileEvent : public DLLEvent
 {
 public:

--- a/pvzclass/Events/PlantAddProjectileEvent.hpp
+++ b/pvzclass/Events/PlantAddProjectileEvent.hpp
@@ -32,3 +32,37 @@ PlantAddProjectileEvent::PlantAddProjectileEvent()
 	};
 	start(STRING(code));
 }
+
+class StarFruitAddProjectileEvent : public DLLEvent
+{
+public:
+	StarFruitAddProjectileEvent();
+	StarFruitAddProjectileEvent(const char* str);
+};
+
+StarFruitAddProjectileEvent::StarFruitAddProjectileEvent()
+{
+	StarFruitAddProjectileEvent::StarFruitAddProjectileEvent("onPlantTakeEatDamage");
+}
+
+StarFruitAddProjectileEvent::StarFruitAddProjectileEvent(const char* str)
+{
+	int procAddress = PVZ::Memory::GetProcAddress(str);
+	hookAddress = 0x45F816;
+	rawlen = 7;
+	BYTE code[] =
+	{
+		PUSH(0),
+		PUSH_EDI,
+		PUSH_ESI,
+		INVOKE(procAddress),
+		ADD_ESP(0x0C),
+
+		TEST_AL_AL,
+		JNZ(6),
+		POPAD,
+		PUSHDWORD(0x45F874),
+		RET
+	};
+	start(STRING(code));
+}

--- a/pvzclass/Events/PlantAddProjectileEvent.hpp
+++ b/pvzclass/Events/PlantAddProjectileEvent.hpp
@@ -9,11 +9,17 @@ class NormalPlantAddProjectileEvent : public DLLEvent
 {
 public:
 	NormalPlantAddProjectileEvent();
+	NormalPlantAddProjectileEvent(const char* str);
 };
 
 NormalPlantAddProjectileEvent::NormalPlantAddProjectileEvent()
 {
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantAddProjectile");
+	NormalPlantAddProjectileEvent::NormalPlantAddProjectileEvent("onPlantAddProjectile");
+}
+
+NormalPlantAddProjectileEvent::NormalPlantAddProjectileEvent(const char* str)
+{
+	int procAddress = PVZ::Memory::GetProcAddress(str);
 	hookAddress = 0x4672B5;
 	rawlen = 6;
 	BYTE code[] =

--- a/pvzclass/Events/SeedPacketUpdateEvent.hpp
+++ b/pvzclass/Events/SeedPacketUpdateEvent.hpp
@@ -1,0 +1,32 @@
+﻿#pragma once
+#include "DLLEvent.h"
+
+// 卡槽卡牌更新事件。
+// 时机上先于原版的更新。
+// @param 触发事件的卡槽卡牌。
+// @return 是否继续结算原版的过程。
+class SeedPacketUpdateEvent : public DLLEvent
+{
+public:
+	SeedPacketUpdateEvent();
+};
+
+SeedPacketUpdateEvent::SeedPacketUpdateEvent()
+{
+	int procAddress = PVZ::Memory::GetProcAddress("onSeedPacketUpdate");
+	hookAddress = 0x487272;
+	rawlen = 7;
+	BYTE code[] =
+	{
+		PUSH_EDI,
+		INVOKE(procAddress),
+		ADD_ESP(4),	
+
+		TEST_AL_AL,
+		JNZ(8),
+		POPAD,
+		MOV_ECX(0x487375),
+		JMP_REG32(REG_ECX)
+	};
+	start(STRING(code));
+}

--- a/pvzclass/Events/ZombieTargetPlantEvent.hpp
+++ b/pvzclass/Events/ZombieTargetPlantEvent.hpp
@@ -1,0 +1,40 @@
+﻿#pragma once
+#include "DLLEvent.h"
+
+// 判断僵尸是否可攻击植物事件。
+// 时机先于一切原版结算。
+// @param 触发事件的僵尸，触发事件的植物，僵尸攻击类型
+// @return 若为正数，则可以索敌；若为 0，则不可索敌；若为负数，结算原版过程。
+class ZombieTargetPlantEvent : public DLLEvent
+{
+public:
+	ZombieTargetPlantEvent();
+};
+
+ZombieTargetPlantEvent::ZombieTargetPlantEvent()
+{
+	int procAddress = PVZ::Memory::GetProcAddress("onZombieTargetPlant");
+	hookAddress = 0x52E4C0;
+	rawlen = 5;
+	BYTE code[] =
+	{
+		PUSH_PTR_ESP_ADD_V(0x28),
+		PUSH_PTR_ESP_ADD_V(0x28),
+		PUSH_ECX,
+		INVOKE(procAddress),
+		ADD_ESP(12),
+
+		TEST_EUX_EVX(REG_EAX, REG_EAX),
+		JS(17),
+		JE(9),
+
+		POPAD,
+		MOV_EAX(1),
+		RETN(8),
+
+		POPAD,
+		XOR_EUX_EVX(REG_EAX, REG_EAX),
+		RETN(8),
+	};
+	start(STRING(code));
+}

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -250,6 +250,7 @@
     <ClInclude Include="Enums\GameObjectType.hpp" />
     <ClInclude Include="Enums\KeyCode.hpp" />
     <ClInclude Include="Enums\StoreItem.hpp" />
+    <ClInclude Include="Enums\ZombieAttackType.hpp" />
     <ClInclude Include="Events\BegTwistFailMoveEvent.hpp" />
     <ClInclude Include="Events\BoardKeyDownEvent.hpp" />
     <ClInclude Include="Events\BoardUpdateGameEvent.hpp" />

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -295,6 +295,7 @@
     <ClInclude Include="Events\SeedPacketMouseDownEvent.hpp" />
     <ClInclude Include="Events\ProjectileCreateEvent.h" />
     <ClInclude Include="Events\PuzzlePhaseCompleteEvent.hpp" />
+    <ClInclude Include="Events\SeedPacketUpdateEvent.hpp" />
     <ClInclude Include="Events\UpdateAppEvent.h" />
     <ClInclude Include="Events\VaseBreakerPopulateEvent.hpp" />
     <ClInclude Include="Events\ZombieBurntEvent.hpp" />

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -346,6 +346,7 @@
     <ClInclude Include="Enums\UpperSoundType.h" />
     <ClInclude Include="Enums\AnimationType.h" />
     <ClInclude Include="Events\ZombieInitAfterEvent.hpp" />
+    <ClInclude Include="Events\ZombieTargetPlantEvent.hpp" />
     <ClInclude Include="Events\ZombieUpdateActionEvent.hpp" />
     <ClInclude Include="Events\ZombieUpdatePlayingEvent.hpp" />
     <ClInclude Include="Flags.h" />

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -467,9 +467,6 @@
     <ClInclude Include="Events\Events.h">
       <Filter>头文件\Events</Filter>
     </ClInclude>
-    <ClInclude Include="Events\ImitaterPlantEvent.h">
-      <Filter>头文件\Events</Filter>
-    </ClInclude>
     <ClInclude Include="Events\NewGameEvent.h">
       <Filter>头文件\Events</Filter>
     </ClInclude>
@@ -727,6 +724,9 @@
     </ClInclude>
     <ClInclude Include="Events\SeedPacketUpdateEvent.hpp">
       <Filter>头文件\Events\SeedPacket</Filter>
+    </ClInclude>
+    <ClInclude Include="Events\ImitaterPlantEvent.h">
+      <Filter>头文件\Events\Plant</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -725,5 +725,8 @@
     <ClInclude Include="Events\PlantTakeDamageEvent.hpp">
       <Filter>头文件\Events\Plant</Filter>
     </ClInclude>
+    <ClInclude Include="Events\SeedPacketUpdateEvent.hpp">
+      <Filter>头文件\Events\SeedPacket</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -731,5 +731,8 @@
     <ClInclude Include="Enums\ZombieAttackType.hpp">
       <Filter>头文件\Enums\Zombie</Filter>
     </ClInclude>
+    <ClInclude Include="Events\ZombieTargetPlantEvent.hpp">
+      <Filter>头文件\Events\Zombie</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -728,5 +728,8 @@
     <ClInclude Include="Events\ImitaterPlantEvent.h">
       <Filter>头文件\Events\Plant</Filter>
     </ClInclude>
+    <ClInclude Include="Enums\ZombieAttackType.hpp">
+      <Filter>头文件\Enums\Zombie</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- `SeedPacketUpdateEvent`，卡槽卡片更新事件；
- `PlantAddProjectileEvent` 现在是一个复合事件；
- 将 `ImitaterPlantEvent` 分类；
- `ZombieAttackType` 枚举，表示僵尸攻击类型；
- `ZombieTargetPlantEvent`，僵尸索敌植物事件。

Fix #15
