### PR TITLE
update Extensions-EnablePortal

### DIFF
--- a/pvzclass/Extensions.h
+++ b/pvzclass/Extensions.h
@@ -73,28 +73,33 @@ inline void ShowHiddenLevel(BOOLEAN b = true)
 	MEMMOD_BYTE(b ? 0x42DF5D : 0x54EBA8, 56, 136);
 }
 
-//启动传送门。
-/// @param state 功能的启用状态，缺省值为 None, 表示创建默认位置传送门及启动传送门。
-inline void EnablePortal(ThreeState::ThreeState state = None)
+/// @brief 启用或禁用传送门功能。
+/// @param b 是否启用传送功能。默认为 `true`。
+/// @param adjust_existed 是否调整现有的传送门。默认为 `false`。
+///        - 当 `b` 为 `true` 且 `adjust_existed` 为 `false` 时，将创建默认位置的传送门。
+///        - 当 `b` 为 `false` 且 `adjust_existed` 为 `true` 时，将移除现有的传送门
+inline void EnablePortal(BOOLEAN b = true, BOOLEAN adjust_existed = false)
 {
-	switch (state)
-	{
-	case None:
-		Creator::__CreatePortal();
-	case Enable:
+	if (b) {
 		PVZ::Memory::WriteMemory<byte>(0x467665, JO);
-		PVZ::Memory::WriteMemory<byte>(0x41FFB4, JO);
+		PVZ::Memory::WriteMemory<byte>(0x41FFB4, JO); 
 		PVZ::Memory::WriteMemory<byte>(0x4248CE, JO);
-		break;
-	case Disable:
+
+		if (!adjust_existed && PVZ::GetBoard().GetBaseAddress() != 0) {
+			Creator::__CreatePortal();
+		}
+	}
+	else {
 		PVZ::Memory::WriteMemory<byte>(0x467665, JNE);
 		PVZ::Memory::WriteMemory<byte>(0x41FFB4, JNE);
 		PVZ::Memory::WriteMemory<byte>(0x4248CE, JNE);
 
-		auto griditems = PVZ::GetBoard().GetAllGriditems();
-		for (DWORD i = 0; i < griditems.size(); i++)
-			if (griditems[i].Type == GriditemType::PortalBlue || griditems[i].Type == GriditemType::PortalYellow)
-				griditems[i].Remove();
+		if (adjust_existed && PVZ::GetBoard().GetBaseAddress() != 0) {
+			auto griditems = PVZ::GetBoard().GetAllGriditems();
+			for (DWORD i = 0; i < griditems.size(); i++)
+				if (griditems[i].Type == GriditemType::PortalBlue || griditems[i].Type == GriditemType::PortalYellow)
+					griditems[i].Remove();
+		}
 	}
 }
 

--- a/pvzclass/Extensions.h
+++ b/pvzclass/Extensions.h
@@ -73,13 +73,29 @@ inline void ShowHiddenLevel(BOOLEAN b = true)
 	MEMMOD_BYTE(b ? 0x42DF5D : 0x54EBA8, 56, 136);
 }
 
-//是否启动传送门。若为“是”，则该方法会自动创建默认的传送门
-inline void EnablePortal(BOOLEAN b = true)
+//启动传送门。
+/// @param state 功能的启用状态，缺省值为 None, 表示创建默认位置传送门及启动传送门。
+inline void EnablePortal(ThreeState::ThreeState state = None)
 {
-	if (b && PVZ::GetBoard().GetBaseAddress() != 0)Creator::__CreatePortal();
-	MEMMOD_BYTE(0x467665, JO, JNE);
-	MEMMOD_BYTE(0x41FFB4, JO, JNE);
-	MEMMOD_BYTE(0x4248CE, JO, JNE);
+	switch (state)
+	{
+	case None:
+		Creator::__CreatePortal();
+	case Enable:
+		PVZ::Memory::WriteMemory<byte>(0x467665, JO);
+		PVZ::Memory::WriteMemory<byte>(0x41FFB4, JO);
+		PVZ::Memory::WriteMemory<byte>(0x4248CE, JO);
+		break;
+	case Disable:
+		PVZ::Memory::WriteMemory<byte>(0x467665, JNE);
+		PVZ::Memory::WriteMemory<byte>(0x41FFB4, JNE);
+		PVZ::Memory::WriteMemory<byte>(0x4248CE, JNE);
+
+		auto griditems = PVZ::GetBoard().GetAllGriditems();
+		for (DWORD i = 0; i < griditems.size(); i++)
+			if (griditems[i].Type == GriditemType::PortalBlue || griditems[i].Type == GriditemType::PortalYellow)
+				griditems[i].Remove();
+	}
 }
 
 //是否固定传送门


### PR DESCRIPTION
1. 原有逻辑
    - `true` 并且在游戏内 -> 创建默认位置的传送门，并启用传送功能； 
    - `false` 或者不在游戏内 -> 禁用传送功能
2. 个人想法
    - 传入参数 `true` 后创建默认位置的传送门，这个必要性太小；
    - 观察一些使用了传送门的项目，多数都是把原来的if语句直接注释掉了，用户可能需要的是：先开启传送门功能，再特定时间创建传送门；如果直接默认创建了，用户则可能需要立马删除传送门；
    - 传入参数 `false` 后不会立即删除传送门；如若禁用了传送功能，那么当前传送门就没有存在必要了，可能会影响使用者，因为无法判断是否还处于生效状态；
3. 修正逻辑
    - None: 默认 -> 创建默认位置的传送门，并启用传送功能
    - Enable：开启 -> 启用传送功能
    - Disable：关闭 -> 禁用传送功能，并且删除场上传送门