### PR TITLE
减小 DLLEvent.h 的链接问题，修复若干新问题

### DIFF
--- a/pvzclass/AsmFunctions.h
+++ b/pvzclass/AsmFunctions.h
@@ -188,6 +188,7 @@
 #define POP_PTR_ESP_ADD_V(v)	0x8F,0x44,0x24,v
 #define POP_PTR_ESP_ADD(v)		0x8F,0x84,0x24,INUMBER(v)
 
+#define MOV_REG32_PTR_ESP_ADD_V(reg,v) 0x8B,0x44+(reg)*8,0x24,v
 #define MOV_PTR_ESP_ADD_V_EUX(ux,v) 0x89,0x44+(ux)*8,0x24,v
 #define MOV_PTR_ESP_ADD_V(v1,v2)	0xC7,0x44,0x24,v1,INUMBER(v2)
 #define MOV_PTR_ESP_ADD(v1,v2)		0xC7,0x84,0x24,INUMBER(v1),INUMBER(v2)

--- a/pvzclass/Events/DLLEvent.cpp
+++ b/pvzclass/Events/DLLEvent.cpp
@@ -1,0 +1,28 @@
+#include "DLLEvent.h"
+
+int DLLEvent::newAddress = 0;
+
+void DLLEvent::start(BYTE* code, int newlen)
+{
+	if (newAddress == 0) newAddress = PVZ::Memory::AllocMemory(4, 0);
+	rawCode = new BYTE[rawlen];
+	PVZ::Memory::ReadArray<BYTE>(hookAddress, rawCode, rawlen);
+	if (rawCode[0] == 0xE8 || rawCode[0] == 0xE9)
+		SETARG(rawCode, 1) = SETARG(rawCode, 1) + hookAddress - newAddress - newlen - 2;
+	BYTE jmpto[] = { JMPFAR(newAddress - (hookAddress + 5)) };
+	PVZ::Memory::WriteArray<BYTE>(hookAddress, jmpto, 5);
+	for (int i = 5; i < rawlen; i++) PVZ::Memory::WriteMemory<BYTE>(hookAddress + i, NOP);
+	BYTE jmpback[] = { JMPFAR(hookAddress - (newAddress + newlen + 7)) };
+	PVZ::Memory::WriteMemory<BYTE>(newAddress, PUSHAD);
+	PVZ::Memory::WriteArray<BYTE>(newAddress + 1, code, newlen);
+	PVZ::Memory::WriteMemory<BYTE>(newAddress + newlen + 1, POPAD);
+	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + 2, rawCode, rawlen);
+	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + rawlen + 2, jmpback, 5);
+	newAddress += newlen + rawlen + 0x10;
+}
+
+void DLLEvent::end()
+{
+	PVZ::Memory::WriteArray<BYTE>(hookAddress, rawCode, rawlen);
+	PVZ::Memory::FreeMemory(newAddress);
+}

--- a/pvzclass/Events/DLLEvent.h
+++ b/pvzclass/Events/DLLEvent.h
@@ -26,33 +26,6 @@ private:
 	static int newAddress;
 };
 
-int DLLEvent::newAddress = 0;
-
-void DLLEvent::start(BYTE* code, int newlen)
-{
-	if (newAddress == 0) newAddress = PVZ::Memory::AllocMemory();
-	rawCode = new BYTE[rawlen];
-	PVZ::Memory::ReadArray<BYTE>(hookAddress, rawCode, rawlen);
-	if (rawCode[0] == 0xE8 || rawCode[0] == 0xE9)
-		SETARG(rawCode, 1) = SETARG(rawCode, 1) + hookAddress - newAddress - newlen - 2;
-	BYTE jmpto[] = { JMPFAR(newAddress - (hookAddress + 5)) };
-	PVZ::Memory::WriteArray<BYTE>(hookAddress, jmpto, 5);
-	for (int i = 5; i < rawlen; i++) PVZ::Memory::WriteMemory<BYTE>(hookAddress + i, NOP);
-	BYTE jmpback[] = { JMPFAR(hookAddress - (newAddress + newlen + 7)) };
-	PVZ::Memory::WriteMemory<BYTE>(newAddress, PUSHAD);
-	PVZ::Memory::WriteArray<BYTE>(newAddress + 1, code, newlen);
-	PVZ::Memory::WriteMemory<BYTE>(newAddress + newlen + 1, POPAD);
-	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + 2, rawCode, rawlen);
-	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + rawlen + 2, jmpback, 5);
-	newAddress += newlen + rawlen + 0x10;
-}
-
-void DLLEvent::end()
-{
-	PVZ::Memory::WriteArray<BYTE>(hookAddress, rawCode, rawlen);
-	PVZ::Memory::FreeMemory(newAddress);
-}
-
 template<DWORD _Hook_Address, DWORD _Raw_Len, DWORD ...Params>
 class DLLEventTemplate : public DLLEvent
 {

--- a/pvzclass/Events/DLLEvent.h
+++ b/pvzclass/Events/DLLEvent.h
@@ -33,6 +33,8 @@ void DLLEvent::start(BYTE* code, int newlen)
 	if (newAddress == 0) newAddress = PVZ::Memory::AllocMemory();
 	rawCode = new BYTE[rawlen];
 	PVZ::Memory::ReadArray<BYTE>(hookAddress, rawCode, rawlen);
+	if (rawCode[0] == 0xE8 || rawCode[0] == 0xE9)
+		SETARG(rawCode, 1) = SETARG(rawCode, 1) + hookAddress - newAddress - newlen - 2;
 	BYTE jmpto[] = { JMPFAR(newAddress - (hookAddress + 5)) };
 	PVZ::Memory::WriteArray<BYTE>(hookAddress, jmpto, 5);
 	for (int i = 5; i < rawlen; i++) PVZ::Memory::WriteMemory<BYTE>(hookAddress + i, NOP);

--- a/pvzclass/Events/DLLEvent.h
+++ b/pvzclass/Events/DLLEvent.h
@@ -55,7 +55,7 @@ template<DWORD _Hook_Address, DWORD _Raw_Len, DWORD ...Params>
 class DLLEventTemplate : public DLLEvent
 {
 protected:
-	void Init(const char* str)
+	void Init(int address)
 	{
 		hookAddress = _Hook_Address;
 		rawlen = _Raw_Len;
@@ -69,10 +69,14 @@ protected:
 			else
 				builder.push_imm32(this->regs[i] - CONST_VAL_MASK);
 
-		builder.invoke(PVZ::Memory::GetProcAddress(str)).add_reg_imm(REG_ESP, this->regs.size() << 2);
+		builder.invoke(address).add_reg_imm(REG_ESP, this->regs.size() << 2);
 		this->InitExtra(builder);
 
 		start(builder.get_code() + 1, builder.get_length() - 1);
+	}
+	void Init(const char* str)
+	{
+		Init(PVZ::Memory::GetProcAddress(str));
 	}
 	virtual void InitExtra(AsmBuilder& builder)
 	{
@@ -89,6 +93,16 @@ protected:
 	virtual void InitExtra(AsmBuilder& builder)
 	{
 		builder.test_al_al().jnz_rel(7).popad().push_imm32(_Cancel_Addr).ret();
+	}
+};
+
+template<DWORD _Hook_Address, DWORD _Raw_Len, DWORD _Cancel_Addr, DWORD ...Params>
+class TrueDLLEventTemplate : public DLLEventTemplate<_Hook_Address, _Raw_Len, Params...>
+{
+protected:
+	virtual void InitExtra(AsmBuilder& builder)
+	{
+		builder.test_al_al().jz_rel(7).popad().push_imm32(_Cancel_Addr).ret();
 	}
 };
 

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -57,6 +57,7 @@
 #include "PlantInitAfterEvent.hpp"
 #include "PlantMouseDownEvent.hpp"
 #include "PlantProduceEvent.hpp"
+#include "PlantRectEvents.hpp"
 #include "PlantShoveledEvent.hpp"
 #include "PlantSquishEvent.h"
 #include "PlantStolenEvent.hpp"

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -51,6 +51,7 @@
 #include "ParseResourceEvent.hpp"
 
 #include "PlantAddProjectileEvent.hpp"
+#include "PlantDamageZombieEvent.hpp"
 #include "PlantDieLowHealthEvent.hpp"
 #include "PlantDoSpecialEvent.hpp"
 #include "PlantEatenEvent.hpp"

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -6,6 +6,8 @@ namespace PVZEvent
 	enum PlantDamageType
 	{
 		PLANTDAMAGETYPE_RETALIATE,
+		PLANTDAMAGETYPE_BOWLING,
+		PLANTDAMAGETYPE_CHOMPER,
 	};
 
 	class PlantDamageZombieEvent
@@ -69,20 +71,122 @@ namespace PVZEvent
 			}
 			Part1(const char* str) : Part1(PVZ::Memory::GetProcAddress(str)) {}
 		};
+		class Part2 : public DLLEvent
+		{
+		public:
+			Part2(int address)
+			{
+				hookAddress = 0x462FC3;
+				rawlen = 5;
+				int tmp = PVZ::Memory::Variable;
+				BYTE code[] =
+				{
+					PUSH_EAX,
+					PUSH(0x14),
+					INVOKE(0x61C130),
+					MOV_EUX_EVX(REG_EBP, REG_EAX),
+					POP_EUX(REG_EAX),
+
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_ESI, 0),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EDI, 4),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 8),
+					MOV_REG32_PTR_ESP_ADD_V(REG_EAX, 0x20),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 0x0C),
+					MOV_PTR_EUX_ADD_V(REG_EBP, 0x10, PLANTDAMAGETYPE_BOWLING),
+
+					PUSH_EBP,
+					INVOKE(address),
+					ADD_ESP(4),
+					MOV_PTR_ADDR_EUX(REG_EBP, tmp),
+					POPAD,
+					PUSH_EBP,
+					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
+
+					POP_EUX(REG_EBP),
+					PUSH_PTR(tmp),
+					INVOKE(0x61C19A),
+					JMP(1)
+				};
+				start(STRING(code));
+			}
+			Part2(const char* str) : Part2(PVZ::Memory::GetProcAddress(str)) {}
+		};
+		class Part3 : public DLLEvent
+		{
+		public:
+			Part3(int address)
+			{
+				hookAddress = 0x4614E0;
+				rawlen = 5;
+				int tmp = PVZ::Memory::Variable;
+				BYTE code[] =
+				{
+					PUSH_EAX,
+					PUSH(0x14),
+					INVOKE(0x61C130),
+					MOV_EUX_EVX(REG_EBP, REG_EAX),
+					POP_EUX(REG_EAX),
+
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_ESI, 0),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EDI, 4),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 8),
+					MOV_REG32_PTR_ESP_ADD_V(REG_EAX, 0x20),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 0x0C),
+					MOV_PTR_EUX_ADD_V(REG_EBP, 0x10, PLANTDAMAGETYPE_CHOMPER),
+
+					PUSH_EBP,
+					INVOKE(address),
+					ADD_ESP(4),
+					MOV_PTR_ADDR_EUX(REG_EBP, tmp),
+					POPAD,
+					PUSH_EBP,
+					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
+
+					POP_EUX(REG_EBP),
+					PUSH_PTR(tmp),
+					INVOKE(0x61C19A),
+					JMP(1)
+				};
+				start(STRING(code));
+			}
+			Part3(const char* str) : Part3(PVZ::Memory::GetProcAddress(str)) {}
+		};
 		Part1* spikerock1;
+		Part2* bowling;
+		Part3* chomper;
 	public:
 		PlantDamageZombieEvent()
 		{
 			const char* str = "onPlantDamageZombie";
 			spikerock1 = new Part1(str);
+			bowling = new Part2(str);
+			chomper = new Part3(str);
 		}
 		PlantDamageZombieEvent(int address)
 		{
 			spikerock1 = new Part1(address);
+			bowling = new Part2(address);
+			chomper = new Part3(address);
 		}
 		void end()
 		{
 			spikerock1->end();
+			bowling->end();
+			chomper->end();
 		}
 	};
 }

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -1,0 +1,88 @@
+#pragma once
+#include "DLLEvent.h"
+
+namespace PVZEvent
+{
+	enum PlantDamageType
+	{
+		PLANTDAMAGETYPE_RETALIATE,
+	};
+
+	class PlantDamageZombieEvent
+	{
+	public:
+		class PZDamageInfo
+		{
+			PVZ::Zombie zombie;
+			PVZ::Plant plant;
+			PVZ::DamageFlags flags;
+			int damage;
+			PlantDamageType type;
+			PZDamageInfo(PVZ::Zombie zombie, PVZ::Plant plant, PVZ::DamageFlags flags, int damage, PlantDamageType type)
+				: zombie(zombie), plant(plant), flags(flags), damage(damage), type(type) {}
+		};
+	private:
+		class Part1 : public DLLEvent
+		{
+		public:
+			Part1(int address)
+			{
+				hookAddress = 0x526D81;
+				rawlen = 5;
+				int tmp = PVZ::Memory::Variable;
+				BYTE code[] =
+				{
+					PUSH_EAX,
+					PUSH(0x14),
+					INVOKE(0x61C130),
+					MOV_EUX_EVX(REG_EBP, REG_EAX),
+					POP_EUX(REG_EAX),
+
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_ESI, 0),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EDI, 4),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 8),
+					MOV_REG32_PTR_ESP_ADD_V(REG_EAX, 0x20),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 0x0C),
+					MOV_PTR_EUX_ADD_V(REG_EBP, 0x10, PLANTDAMAGETYPE_RETALIATE),
+
+					PUSH_EBP,
+					INVOKE(address),
+					ADD_ESP(4),
+					MOV_PTR_ADDR_EUX(REG_EBP, tmp),
+					POPAD,
+					PUSH_EBP,
+					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
+
+					POP_EUX(REG_EBP),
+					PUSH_PTR(tmp),
+					INVOKE(0x61C19A),
+					JMP(1)
+				};
+				start(STRING(code));
+			}
+			Part1(const char* str) : Part1(PVZ::Memory::GetProcAddress(str)) {}
+		};
+		Part1* spikerock1;
+	public:
+		PlantDamageZombieEvent()
+		{
+			const char* str = "onPlantDamageZombie";
+			spikerock1 = new Part1(str);
+		}
+		PlantDamageZombieEvent(int address)
+		{
+			spikerock1 = new Part1(address);
+		}
+		void end()
+		{
+			spikerock1->end();
+		}
+	};
+}

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -8,6 +8,7 @@ namespace PVZEvent
 		PLANTDAMAGETYPE_RETALIATE,
 		PLANTDAMAGETYPE_BOWLING,
 		PLANTDAMAGETYPE_CHOMPER,
+		PLANTDAMAGETYPE_AOE,
 	};
 
 	class PlantDamageZombieEvent
@@ -165,9 +166,105 @@ namespace PVZEvent
 			}
 			Part3(const char* str) : Part3(PVZ::Memory::GetProcAddress(str)) {}
 		};
+		class Part4 : public DLLEvent
+		{
+		public:
+			Part4(int address)
+			{
+				hookAddress = 0x4607B2;
+				rawlen = 5;
+				int tmp = PVZ::Memory::Variable;
+				BYTE code[] =
+				{
+					PUSH_EAX,
+					PUSH(0x14),
+					INVOKE(0x61C130),
+					MOV_EUX_EVX(REG_EBP, REG_EAX),
+					POP_EUX(REG_EAX),
+
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_ESI, 0),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EDI, 4),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 8),
+					MOV_REG32_PTR_ESP_ADD_V(REG_EAX, 0x20),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EBP, REG_EAX, 0x0C),
+					MOV_PTR_EUX_ADD_V(REG_EBP, 0x10, PLANTDAMAGETYPE_AOE),
+
+					PUSH_EBP,
+					INVOKE(address),
+					ADD_ESP(4),
+					MOV_PTR_ADDR_EUX(REG_EBP, tmp),
+					POPAD,
+					PUSH_EBP,
+					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
+
+					POP_EUX(REG_EBP),
+					PUSH_PTR(tmp),
+					INVOKE(0x61C19A),
+					JMP(1)
+				};
+				start(STRING(code));
+			}
+			Part4(const char* str) : Part4(PVZ::Memory::GetProcAddress(str)) {}
+		};
+		class Part5 : public DLLEvent
+		{
+		public:
+			Part5(int address)
+			{
+				hookAddress = 0x45EE22;
+				rawlen = 5;
+				int tmp = PVZ::Memory::Variable;
+				BYTE code[] =
+				{
+					PUSH_EAX,
+					PUSH(0x14),
+					INVOKE(0x61C130),
+					MOV_EUX_EVX(REG_EDX, REG_EAX),
+					POP_EUX(REG_EAX),
+
+					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_ESI, 0),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EDI, 4),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EBP, 8),
+					MOV_REG32_PTR_ESP_ADD_V(REG_EAX, 0x20),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EAX, 0x0C),
+					MOV_PTR_EUX_ADD_V(REG_EDX, 0x10, PLANTDAMAGETYPE_AOE),
+
+					PUSH_EDX,
+					INVOKE(address),
+					ADD_ESP(4),
+					MOV_PTR_ADDR_EUX(REG_EDX, tmp),
+					POPAD,
+					PUSH_EDX,
+					MOV_EUX_PTR_ADDR(REG_EDX, tmp),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EDX, 0x0C),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+
+					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EDX, 0),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EDX, 4),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EBP, REG_EDX, 8),
+
+					POP_EUX(PUSH_EDX),
+					PUSH_PTR(tmp),
+					INVOKE(0x61C19A),
+					JMP(1)
+				};
+				start(STRING(code));
+			}
+			Part5(const char* str) : Part5(PVZ::Memory::GetProcAddress(str)) {}
+		};
 		Part1* spikerock1;
 		Part2* bowling;
 		Part3* chomper;
+		Part4* squash;
+		Part5* rowarea;
 	public:
 		PlantDamageZombieEvent()
 		{
@@ -175,18 +272,23 @@ namespace PVZEvent
 			spikerock1 = new Part1(str);
 			bowling = new Part2(str);
 			chomper = new Part3(str);
+			squash = new Part4(str);
+			rowarea = new Part5(str);
 		}
 		PlantDamageZombieEvent(int address)
 		{
 			spikerock1 = new Part1(address);
 			bowling = new Part2(address);
 			chomper = new Part3(address);
+			squash = new Part4(address);
+			rowarea = new Part5(address);
 		}
 		void end()
 		{
 			spikerock1->end();
 			bowling->end();
 			chomper->end();
+			squash->end();
 		}
 	};
 }

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -16,6 +16,7 @@ namespace PVZEvent
 	public:
 		class PZDamageInfo
 		{
+		public:
 			PVZ::Zombie zombie;
 			PVZ::Plant plant;
 			PVZ::DamageFlags flags;
@@ -38,6 +39,7 @@ namespace PVZEvent
 					PUSH_EAX,
 					PUSH(0x14),
 					INVOKE(0x61C130),
+					ADD_ESP(4),
 					MOV_EUX_EVX(REG_EBP, REG_EAX),
 					POP_EUX(REG_EAX),
 
@@ -64,8 +66,11 @@ namespace PVZEvent
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
 
 					POP_EUX(REG_EBP),
+					PUSH_EAX, PUSH_ECX, PUSH_EDX,
 					PUSH_PTR(tmp),
 					INVOKE(0x61C19A),
+					ADD_ESP(4),
+					POP_EUX(REG_EDX), POP_EUX(REG_ECX), POP_EUX(REG_EAX),
 					JMP(1)
 				};
 				start(STRING(code));
@@ -85,6 +90,7 @@ namespace PVZEvent
 					PUSH_EAX,
 					PUSH(0x14),
 					INVOKE(0x61C130),
+					ADD_ESP(4),
 					MOV_EUX_EVX(REG_EBP, REG_EAX),
 					POP_EUX(REG_EAX),
 
@@ -111,8 +117,11 @@ namespace PVZEvent
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
 
 					POP_EUX(REG_EBP),
+					PUSH_EAX, PUSH_ECX, PUSH_EDX,
 					PUSH_PTR(tmp),
 					INVOKE(0x61C19A),
+					ADD_ESP(4),
+					POP_EUX(REG_EDX), POP_EUX(REG_ECX), POP_EUX(REG_EAX),
 					JMP(1)
 				};
 				start(STRING(code));
@@ -132,6 +141,7 @@ namespace PVZEvent
 					PUSH_EAX,
 					PUSH(0x14),
 					INVOKE(0x61C130),
+					ADD_ESP(4),
 					MOV_EUX_EVX(REG_EBP, REG_EAX),
 					POP_EUX(REG_EAX),
 
@@ -158,8 +168,11 @@ namespace PVZEvent
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
 
 					POP_EUX(REG_EBP),
+					PUSH_EAX, PUSH_ECX, PUSH_EDX,
 					PUSH_PTR(tmp),
 					INVOKE(0x61C19A),
+					ADD_ESP(4),
+					POP_EUX(REG_EDX), POP_EUX(REG_ECX), POP_EUX(REG_EAX),
 					JMP(1)
 				};
 				start(STRING(code));
@@ -179,6 +192,7 @@ namespace PVZEvent
 					PUSH_EAX,
 					PUSH(0x14),
 					INVOKE(0x61C130),
+					ADD_ESP(4),
 					MOV_EUX_EVX(REG_EBP, REG_EAX),
 					POP_EUX(REG_EAX),
 
@@ -205,8 +219,11 @@ namespace PVZEvent
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 8),
 
 					POP_EUX(REG_EBP),
+					PUSH_EAX, PUSH_ECX, PUSH_EDX,
 					PUSH_PTR(tmp),
 					INVOKE(0x61C19A),
+					ADD_ESP(4),
+					POP_EUX(REG_EDX), POP_EUX(REG_ECX), POP_EUX(REG_EAX),
 					JMP(1)
 				};
 				start(STRING(code));
@@ -226,34 +243,38 @@ namespace PVZEvent
 					PUSH_EAX,
 					PUSH(0x14),
 					INVOKE(0x61C130),
+					ADD_ESP(4),
 					MOV_EUX_EVX(REG_EDX, REG_EAX),
 					POP_EUX(REG_EAX),
 
 					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_ESI, 0),
-					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EDI, 4),
-					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EBP, 8),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EBP, 4),
+					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EAX, 8),
 					MOV_REG32_PTR_ESP_ADD_V(REG_EAX, 0x20),
 					MOV_PTR_EUX_ADD_V_EVX(REG_EDX, REG_EAX, 0x0C),
 					MOV_PTR_EUX_ADD_V(REG_EDX, 0x10, PLANTDAMAGETYPE_AOE),
 
 					PUSH_EDX,
 					INVOKE(address),
-					ADD_ESP(4),
+					POP_EUX(REG_EDX),
 					MOV_PTR_ADDR_EUX(REG_EDX, tmp),
 					POPAD,
 					PUSH_EDX,
 					MOV_EUX_PTR_ADDR(REG_EDX, tmp),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EDX, 0x0C),
-					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 4),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EDX, 0),
-					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EDX, 4),
-					MOV_EUX_PTR_EVX_ADD_V(REG_EBP, REG_EDX, 8),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EBP, REG_EDX, 4),
+					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EDX, 8),
 
-					POP_EUX(PUSH_EDX),
+					POP_EUX(REG_EDX),
+					PUSH_EAX, PUSH_ECX, PUSH_EDX,
 					PUSH_PTR(tmp),
 					INVOKE(0x61C19A),
+					ADD_ESP(4),
+					POP_EUX(REG_EDX), POP_EUX(REG_ECX), POP_EUX(REG_EAX),
 					JMP(1)
 				};
 				start(STRING(code));
@@ -269,14 +290,7 @@ namespace PVZEvent
 		PlantDamageZombieEvent()
 		{
 			const char* str = "onPlantDamageZombie";
-			spikerock1 = new Part1(str);
-			bowling = new Part2(str);
-			chomper = new Part3(str);
-			squash = new Part4(str);
-			rowarea = new Part5(str);
-		}
-		PlantDamageZombieEvent(int address)
-		{
+			auto address = PVZ::Memory::GetProcAddress(str);
 			spikerock1 = new Part1(address);
 			bowling = new Part2(address);
 			chomper = new Part3(address);
@@ -289,6 +303,7 @@ namespace PVZEvent
 			bowling->end();
 			chomper->end();
 			squash->end();
+			rowarea->end();
 		}
 	};
 }

--- a/pvzclass/Events/PlantRectEvents.hpp
+++ b/pvzclass/Events/PlantRectEvents.hpp
@@ -1,0 +1,24 @@
+﻿#pragma once
+#include "DLLEvent.h"
+
+/// @brief 获取植物受击范围事件
+/// @param 依次为：触发事件的植物；受击范围矩形的指针。
+/// @retval true 是否使用自定义返回值，跳过原版函数
+/// @retval false 执行原版函数
+class GetPlantRectEvent : public TrueDLLEventTemplate<0x467EF0, 7, 0x467F85, REG_EAX, REG_ECX>
+{
+public:
+	GetPlantRectEvent() : TrueDLLEventTemplate() { Init("getPlantRect"); };
+	GetPlantRectEvent(int proc_addr) : TrueDLLEventTemplate() { Init(proc_addr); }
+};
+
+/// @brief 获取植物攻击范围事件
+/// @param 依次为：触发事件的植物；植物是否使用副武器，范围矩形的指针。
+/// @retval true 是否使用自定义返回值，跳过原版函数
+/// @retval false 执行原版函数
+class GetPlantAttackRectEvent : public TrueDLLEventTemplate<0x467F90, 5, 0x4681D7, REG_EAX, MEM_ESP_ADD(0x28), REG_ECX>
+{
+public:
+	GetPlantAttackRectEvent() : TrueDLLEventTemplate() { Init("getPlantAttackRect"); };
+	GetPlantAttackRectEvent(int proc_addr) : TrueDLLEventTemplate() { Init(proc_addr); }
+};

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -234,7 +234,7 @@ namespace PVZ
 		INT_PROPERTY(Sun, __get_Sun, __set_Sun, 0x5560);
 		PROPERTY(int, __get_WaveCount, __set_WaveCount) WaveCount;
 		/*exclude preparing time*/
-		INT_READONLY_PROPERTY(PlayingTime, __get_PlayingTime, 0x5568);
+		INT_PROPERTY(PlayingTime, __get_PlayingTime, __get_PlayingTime, 0x5568);
 		/*include preparing time*/
 		INT_READONLY_PROPERTY(PlayingTime2, __get_PlayingTime2, 0x556C);
 		/*lose focus and recount*/

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -234,7 +234,7 @@ namespace PVZ
 		INT_PROPERTY(Sun, __get_Sun, __set_Sun, 0x5560);
 		PROPERTY(int, __get_WaveCount, __set_WaveCount) WaveCount;
 		/*exclude preparing time*/
-		INT_PROPERTY(PlayingTime, __get_PlayingTime, __get_PlayingTime, 0x5568);
+		INT_PROPERTY(PlayingTime, __get_PlayingTime, __set_PlayingTime, 0x5568);
 		/*include preparing time*/
 		INT_READONLY_PROPERTY(PlayingTime2, __get_PlayingTime2, 0x556C);
 		/*lose focus and recount*/

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -293,6 +293,7 @@
     <ClInclude Include="Events\PlantInitAfterEvent.hpp" />
     <ClInclude Include="Events\PlantMouseDownEvent.hpp" />
     <ClInclude Include="Events\PlantProduceEvent.hpp" />
+    <ClInclude Include="Events\PlantRectEvents.hpp" />
     <ClInclude Include="Events\PlantShoveledEvent.hpp" />
     <ClInclude Include="Events\PlantSquishEvent.h" />
     <ClInclude Include="Events\PlantStolenEvent.hpp" />

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -231,6 +231,7 @@
     <ClCompile Include="Enums\ZombieState.cpp" />
     <ClCompile Include="Enums\ZombieType.cpp" />
     <ClCompile Include="Enums\MagnetItemType.cpp" />
+    <ClCompile Include="Events\DLLEvent.cpp" />
     <ClCompile Include="Events\PlantDamageZombieEvent.hpp" />
     <ClCompile Include="ProcessOpener.cpp" />
     <ClCompile Include="Classes\Projectile.cpp" />

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -231,6 +231,7 @@
     <ClCompile Include="Enums\ZombieState.cpp" />
     <ClCompile Include="Enums\ZombieType.cpp" />
     <ClCompile Include="Enums\MagnetItemType.cpp" />
+    <ClCompile Include="Events\PlantDamageZombieEvent.hpp" />
     <ClCompile Include="ProcessOpener.cpp" />
     <ClCompile Include="Classes\Projectile.cpp" />
     <ClCompile Include="PVZ.cpp" />

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -306,6 +306,9 @@
     <ClCompile Include="Classes\TodParticleSystem.cpp">
       <Filter>源文件\Classes</Filter>
     </ClCompile>
+    <ClCompile Include="Events\PlantDamageZombieEvent.hpp">
+      <Filter>头文件\Events\Plant</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ProcessOpener.h">

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -758,5 +758,8 @@
     <ClInclude Include="Classes\SaveData.hpp">
       <Filter>头文件\Classes</Filter>
     </ClInclude>
+    <ClInclude Include="Events\PlantRectEvents.hpp">
+      <Filter>头文件\Events\Plant</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -70,6 +70,9 @@
     <Filter Include="头文件\Events\Resource">
       <UniqueIdentifier>{e097e27d-895f-4d97-aaf9-e3461a9e61ad}</UniqueIdentifier>
     </Filter>
+    <Filter Include="源文件\Events">
+      <UniqueIdentifier>{48b1875c-9a74-4209-962b-04c7e5ca420f}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PVZ.cpp">
@@ -308,6 +311,9 @@
     </ClCompile>
     <ClCompile Include="Events\PlantDamageZombieEvent.hpp">
       <Filter>头文件\Events\Plant</Filter>
+    </ClCompile>
+    <ClCompile Include="Events\DLLEvent.cpp">
+      <Filter>源文件\Events</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- 将部分 DLLEvent.h 的内容搬至源代码，修复部分重复定义问题。
- 添加了 TrueDLLEventTemplate，作为 BoolDLLEventTemplate 的对称类。
- 添加了复合事件 PlantDamageZombieEvent，用于处理植物直接对僵尸造成伤害的情况。
- 添加了 GetPlantRectEvent 事件，处理植物受击范围；
- 添加了 GetPlantAttackRectEvent 事件，处理植物攻击范围；
- Fix #14 
- Board::PlayingTime 现在可写。