### PR TITLE
若干事件更新和其他优化

### DIFF
--- a/pvzclass/Classes/Board.cpp
+++ b/pvzclass/Classes/Board.cpp
@@ -1,5 +1,12 @@
-#include "../PVZ.h"
+﻿#include "../PVZ.h"
 #include "../Const.h"
+
+void PVZ::Board::SetMemSize(int NewSize)
+{
+	if (NewSize < 0x57B0)
+		return;
+	PVZ::Memory::WriteMemory<int>(0x44F60F, NewSize);
+}
 
 PVZ::PVZApp PVZ::Board::GetPVZApp()
 {

--- a/pvzclass/Classes/Plant.cpp
+++ b/pvzclass/Classes/Plant.cpp
@@ -212,6 +212,18 @@ void PVZ::Plant::SetAnimation(LPCSTR animName, byte animPlayArg, int imagespeed)
 	PVZ::Memory::FreeMemory(Address);
 }
 
+AsmBuilder PlayIdleAnim_builder = AsmBuilder();
+void PVZ::Plant::PlayIdleAnim(float speed)
+{
+	PlayIdleAnim_builder.clear()
+		.push_float(speed)
+		.mov_reg_imm(REG_EDI, GetBaseAddress())
+		.invoke(0x468280)
+		.ret();
+
+	PVZ::Memory::Execute(PlayIdleAnim_builder);
+}
+
 PVZ::Plant::MagnetItem::MagnetItem(int address)
 {
 	BaseAddress = address;

--- a/pvzclass/Classes/Plant.cpp
+++ b/pvzclass/Classes/Plant.cpp
@@ -8,19 +8,6 @@ PVZ::Plant::Plant(int indexoraddress)
 		BaseAddress = Memory::ReadMemory<int>(PVZBASEADDRESS + 0xAC) + indexoraddress * MemSize;
 }
 
-byte __asm__Plant_memset[]
-{
-	MOV_PTR_EUX_ADD__EVX(REG_EBX, REG_EDI, 0x00BC),
-	PUSH_EUX(REG_EAX),
-	MOV_EUX(REG_EAX, 0),
-	0x89, 0x3C, 0x18,
-	ADD_EUX(REG_EAX, 4),
-	CMP_EUX_DWORD(REG_EAX, 0),
-	JNG(242), // -14
-	POP_EUX(REG_EAX),
-	JMPFAR(0)
-};
-
 void PVZ::Plant::SetMemSize(int NewSize = 0x14C, int NewCount = 1024)
 {
 	if (NewSize < 0x14C)
@@ -53,13 +40,6 @@ void PVZ::Plant::SetMemSize(int NewSize = 0x14C, int NewCount = 1024)
 	Memory::WriteMemory<int>(0x52CBC0, NewSize);
 	Memory::WriteMemory<int>(0x530433, NewSize);
 	Memory::WriteMemory<int>(0x5304A5, NewSize);
-	Memory::WriteMemory<byte>(0x45DCA8, 0xE9);
-	Memory::WriteMemory<int>(0x45DCA9, PVZ::Memory::Variable + 400 - 5 - 0x45DCA8);
-	Memory::WriteMemory<byte>(0x45DCAD, NOP);
-	SETARG(__asm__Plant_memset, 8) = 0x14C;
-	SETARG(__asm__Plant_memset, 20) = NewSize - 4;
-	SETARG(__asm__Plant_memset, 28) = 0x45DCAE - 5 - (Memory::Variable + 427);
-	PVZ::Memory::WriteArray<byte>(PVZ::Memory::Variable + 400, STRING(__asm__Plant_memset));
 }
 
 PVZ::Animation PVZ::Plant::GetAnimationPart1()

--- a/pvzclass/Creators.cpp
+++ b/pvzclass/Creators.cpp
@@ -124,6 +124,17 @@ byte __asm__CreatePortalpieces2[15]
 	JMPFAR(0),
 };
 
+byte __asm__Random[]
+{
+	PUSH_ECX,
+	PUSH_EDX,
+	MOV_EAX(0),
+	INVOKE(0x5AF400),
+	POP_EUX(REG_EDX),
+	POP_EUX(REG_ECX),
+	RET
+};
+
 void Creator::AsmInit()
 {
 	SETARG(__asm__CreateProjectile2, 50) = PVZ::Memory::Variable + 8;
@@ -137,6 +148,8 @@ void Creator::AsmInit()
 	PVZ::Memory::WriteArray<byte>(0x42706C, STRING(__asm__CreatePortalpieces1));
 	SETARG(__asm__CreatePortalpieces2, 11) = 0x427076 - 5 - (PVZ::Memory::Variable + 210);
 	PVZ::Memory::WriteArray<byte>(PVZ::Memory::Variable + 200, STRING(__asm__CreatePortalpieces2));
+	// random
+	PVZ::Memory::WriteArray<byte>(PVZ::Memory::Variable + 225, STRING(__asm__Random));
 }
 
 byte __asm__Asm__Reset[10]
@@ -608,6 +621,13 @@ void Creator::__ClearZombiePreview()
 {
 	SETARG(__asm__ClearZombiePreview, 1) = PVZBASEADDRESS;
 	PVZ::Memory::Execute(STRING(__asm__ClearZombiePreview));
+}
+
+int Creator::Rand(const int range)
+{
+	PVZ::Memory::WriteMemory<int>(PVZ::Memory::Variable + 228, range);
+	int (*func)() = (int (*)())(PVZ::Memory::Variable + 225);
+	return func();
 }
 
 byte __asm__CreateZombieInLevel[19]

--- a/pvzclass/Creators.cpp
+++ b/pvzclass/Creators.cpp
@@ -623,13 +623,6 @@ void Creator::__ClearZombiePreview()
 	PVZ::Memory::Execute(STRING(__asm__ClearZombiePreview));
 }
 
-int Creator::Rand(const int range)
-{
-	PVZ::Memory::WriteMemory<int>(PVZ::Memory::Variable + 228, range);
-	int (*func)() = (int (*)())(PVZ::Memory::Variable + 225);
-	return func();
-}
-
 byte __asm__CreateZombieInLevel[19]
 {
 	MOV_EDI(0),

--- a/pvzclass/Creators.h
+++ b/pvzclass/Creators.h
@@ -269,7 +269,12 @@ namespace Creator
 	/// @see AsmInit()
 	/// @param range 随机数的上限，必须大于 0 。
 	/// @return 一个小于 range1 的随机正整数
-	inline int Rand(const int range);
+	inline int Rand(const int range)
+	{
+		PVZ::Memory::WriteMemory<int>(PVZ::Memory::Variable + 228, range);
+		int (*func)() = (int (*)())(PVZ::Memory::Variable + 225);
+		return func();
+	}
 
 	/// @brief 刷新出怪列表
 	/// @param ztypes 僵尸类型

--- a/pvzclass/Creators.h
+++ b/pvzclass/Creators.h
@@ -263,6 +263,14 @@ namespace Creator
 	/// @brief 清除选卡界面的预览僵尸
 	void __ClearZombiePreview();
 
+	/// @brief 使用 PVZ 主程序的随机数生成器（一个 mt19937）获取一个随机正整数。
+	/// @attention 你需要先调用一次 AsmInit() 后才能使用这个函数。
+	/// @attention 该函数仅供 pvzdll 使用，在应用程序直接使用会导致崩溃。
+	/// @see AsmInit()
+	/// @param range 随机数的上限，必须大于 0 。
+	/// @return 一个小于 range1 的随机正整数
+	inline int Rand(const int range);
+
 	/// @brief 刷新出怪列表
 	/// @param ztypes 僵尸类型
 	/// @param length ztypes 的元素数

--- a/pvzclass/Events/BoardInitAfterEvent.hpp
+++ b/pvzclass/Events/BoardInitAfterEvent.hpp
@@ -1,0 +1,15 @@
+﻿#pragma once
+#include "DLLEvent.h"
+
+namespace PVZEvent
+{
+	/// @brief Board 初始化完毕事件。
+	/// @param 初始化的 Board 对象
+	class BoardInitAfterEvent : public DLLEventTemplate<0x408668, 6, REG_EAX>
+	{
+	public:
+		BoardInitAfterEvent(const char* str) : DLLEventTemplate() { Init(str); };
+		BoardInitAfterEvent(int address) : DLLEventTemplate() { Init(address); };
+		BoardInitAfterEvent() : DLLEventTemplate() { Init("onBoardInitAfter"); };
+	};
+}

--- a/pvzclass/Events/DLLEvent.h
+++ b/pvzclass/Events/DLLEvent.h
@@ -165,11 +165,11 @@ protected:
 	virtual void InitExtra(AsmBuilder& builder)
 	{
 		if (_Out_Param < MEM_ESP_ADD_MASK)
-			builder.fstp_ST(_Out_Param).popad();
+			builder.fstp_ST(_Out_Param);
 		else if (_Out_Param < CONST_VAL_MASK)
-			builder.fstp_m32_esp_imm8(_Out_Param).popad();
+			builder.fstp_m32_esp_imm8(_Out_Param);
 		else
-			builder.fstp(_Out_Param - CONST_VAL_MASK).popad();
+			builder.fstp(_Out_Param - CONST_VAL_MASK);
 
 		if (_Exit)
 			builder.ret();

--- a/pvzclass/Events/DLLEvent.h
+++ b/pvzclass/Events/DLLEvent.h
@@ -130,7 +130,7 @@ protected:
 		{
 			if (_Lower_Bound > INT32_MIN)
 				builder.cmp_reg_imm(REG_EAX, _Lower_Bound).jl_rel(5 + (_Exit ? 1 : 2));
-			builder.mov_mem_esp_add_imm8_reg(0x1C - (_Out_Param << 2), REG_EAX).popad();
+			builder.mov_mem_esp_add_imm8_reg(0x1C - ((_Out_Param & 7) << 2), REG_EAX).popad();
 		}
 		else if (_Out_Param < CONST_VAL_MASK)
 		{

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "BoardUpdateGameEvent.hpp"
 #include "CoinCollectEvent.h"
 #include "CoinCreateEvent.h"
@@ -40,6 +40,7 @@
 #include "ZombieUpdatePlayingEvent.hpp"
 
 #include "BegTwistFailMoveEvent.hpp"
+#include "BoardInitAfterEvent.hpp"
 #include "BoardKeyDownEvent.hpp"
 #include "CalcSunCostEvent.hpp"
 #include "ChallengeInitAfterEvent.hpp"

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -14,9 +14,10 @@ namespace PVZEvent
 	class PlantDamageZombieEvent
 	{
 	public:
-		template<typename P = PVZ::Plant, typename = enable_if_t<is_base_of<PVZ::Plant, P>::value>,
-			typename Z = PVZ::Zombie, typename = enable_if_t<is_base_of<PVZ::Zombie, Z>::value>>
-			class PZDamageInfo
+		template<typename P = PVZ::Plant, typename Z = PVZ::Zombie,
+			typename = enable_if_t<is_base_of<PVZ::Plant, P>::value>, 
+			typename = enable_if_t<is_base_of<PVZ::Zombie, Z>::value>>
+		class PZDamageInfo
 		{
 		public:
 			Z zombie;

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -287,15 +287,19 @@ namespace PVZEvent
 		Part4* squash;
 		Part5* rowarea;
 	public:
-		PlantDamageZombieEvent()
+		PlantDamageZombieEvent(int address)
 		{
-			const char* str = "onPlantDamageZombie";
-			auto address = PVZ::Memory::GetProcAddress(str);
 			spikerock1 = new Part1(address);
 			bowling = new Part2(address);
 			chomper = new Part3(address);
 			squash = new Part4(address);
 			rowarea = new Part5(address);
+		}
+		PlantDamageZombieEvent()
+		{
+			const char* str = "onPlantDamageZombie";
+			auto address = PVZ::Memory::GetProcAddress(str);
+			PlantDamageZombieEvent(address);
 		}
 		void end()
 		{

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "DLLEvent.h"
 
 namespace PVZEvent
@@ -14,16 +14,19 @@ namespace PVZEvent
 	class PlantDamageZombieEvent
 	{
 	public:
-		class PZDamageInfo
+		template<typename P = PVZ::Plant, typename = enable_if_t<is_base_of<PVZ::Plant, P>::value>,
+			typename Z = PVZ::Zombie, typename = enable_if_t<is_base_of<PVZ::Zombie, Z>::value>>
+			class PZDamageInfo
 		{
 		public:
-			PVZ::Zombie zombie;
-			PVZ::Plant plant;
+			Z zombie;
+			P plant;
 			PVZ::DamageFlags flags;
 			int damage;
 			PlantDamageType type;
-			PZDamageInfo(PVZ::Zombie zombie, PVZ::Plant plant, PVZ::DamageFlags flags, int damage, PlantDamageType type)
-				: zombie(zombie), plant(plant), flags(flags), damage(damage), type(type) {}
+			PZDamageInfo(Z zombie, P plant, PVZ::DamageFlags flags, int damage, PlantDamageType type)
+				: zombie(zombie), plant(plant), flags(flags), damage(damage), type(type) {
+			}
 		};
 	private:
 		class Part1 : public DLLEvent
@@ -297,9 +300,7 @@ namespace PVZEvent
 		}
 		PlantDamageZombieEvent()
 		{
-			const char* str = "onPlantDamageZombie";
-			auto address = PVZ::Memory::GetProcAddress(str);
-			PlantDamageZombieEvent(address);
+			PlantDamageZombieEvent(PVZ::Memory::GetProcAddress("onPlantDamageZombie"));
 		}
 		void end()
 		{

--- a/pvzclass/Events/PlantInitAfterEvent.hpp
+++ b/pvzclass/Events/PlantInitAfterEvent.hpp
@@ -1,25 +1,12 @@
 ﻿#pragma once
 #include "DLLEvent.h"
 
-// 植物初始化之后的事件。
-// 无返回值
-/// @param 依次为：触发事件的植物。
-class PlantInitAfterEvent : public DLLEvent
+/// @brief 植物初始化完成事件
+/// @param 触发事件的植物
+class PlantInitAfterEvent : public DLLEventTemplate<0x45E7AF, 7, MEM_ESP_ADD(0x28)>
 {
 public:
-	PlantInitAfterEvent();
+	PlantInitAfterEvent(const char* str) : DLLEventTemplate() { Init(str); };
+	PlantInitAfterEvent(int address) : DLLEventTemplate() { Init(address); };
+	PlantInitAfterEvent() : PlantInitAfterEvent("onPlantInitAfter") {};
 };
-
-PlantInitAfterEvent::PlantInitAfterEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantInitAfter");
-	hookAddress = 0x45E7AF;
-	rawlen = 7;
-	BYTE code[] =
-	{
-		PUSH_PTR_ESP_ADD_V(0x28),
-		INVOKE(procAddress),
-		ADD_ESP(4),
-	};
-	start(STRING(code));
-}

--- a/pvzclass/Events/ProjectileImageEvent.hpp
+++ b/pvzclass/Events/ProjectileImageEvent.hpp
@@ -55,7 +55,7 @@ namespace PVZEvent
 	/// @brief 子弹图片大小事件。默认获取的导出函数名为 GetProjectileImageSize 。
 	/// @param 依次为：子弹基址、原始大小。
 	/// @return 调整后的子弹图片大小。
-	class ProjectileImageSizeEvent : public FloatDLLEventTemplate<0x46E6D3, MEM_ESP_ADD(0x30), false,
+	class ProjectileImageSizeEvent : public FloatDLLEventTemplate<0x46E6D3, 6, MEM_ESP_ADD(0x30), false,
 		MEM_ESP_ADD(0x30), REG_ESI>
 	{
 	public:

--- a/pvzclass/Events/UpdateGameObjectsEvent.h
+++ b/pvzclass/Events/UpdateGameObjectsEvent.h
@@ -1,22 +1,13 @@
 ﻿#pragma once
 #include "DLLEvent.h"
 
-// 更新 GameObject 事件。
-// 时序上先于 PVZ 本体的更新函数。
-// 该事件不可被取消。
-// 该事件需要测试。
+/// @brief 更新 GameObject 事件。\n
+///		时序上先于 PVZ 本体的更新函数。
 /// @param 更新的 Board。
-class UpdateGameObjectsEvent : public DLLEvent
+class UpdateGameObjectsEvent : public DLLEventTemplate<0x4130D0, 5, REG_EBX>
 {
 public:
-	UpdateGameObjectsEvent();
+	UpdateGameObjectsEvent(const char* str) : DLLEventTemplate() { Init(str); };
+	UpdateGameObjectsEvent(int address) : DLLEventTemplate() { Init(address); };
+	UpdateGameObjectsEvent() : DLLEventTemplate() { Init("onGameObjectsUpdate"); };
 };
-
-UpdateGameObjectsEvent::UpdateGameObjectsEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onGameObjectsUpdate");
-	hookAddress = 0x4130D0;
-	rawlen = 5;
-	BYTE code[] = { PUSH_EBX, INVOKE(procAddress), ADD_ESP(4) };
-	start(STRING(code));
-}

--- a/pvzclass/Events/ZombieInitAfterEvent.hpp
+++ b/pvzclass/Events/ZombieInitAfterEvent.hpp
@@ -1,22 +1,12 @@
-#pragma once
+﻿#pragma once
 #include "DLLEvent.h"
 
-class ZombieInitAfterEvent : public DLLEvent
+/// @brief 僵尸初始化完成事件
+/// @param 初始化的 Zombie 的基址。
+class ZombieInitAfterEvent : public DLLEventTemplate<0x524035, 5, REG_EDI>
 {
 public:
-	ZombieInitAfterEvent();
+	ZombieInitAfterEvent(const char* str) : DLLEventTemplate() { Init(str); };
+	ZombieInitAfterEvent(int address) : DLLEventTemplate() { Init(address); };
+	ZombieInitAfterEvent() : DLLEventTemplate() { Init("onZombieInitAfter"); };
 };
-
-ZombieInitAfterEvent::ZombieInitAfterEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onZombieInitAfter");
-	hookAddress = 0x524035;
-	rawlen = 5;
-	BYTE code[] =
-	{
-		PUSH_EDI,
-		INVOKE(procAddress),
-		ADD_ESP(4)
-	};
-	start(STRING(code));
-}

--- a/pvzclass/Memory.hpp
+++ b/pvzclass/Memory.hpp
@@ -16,8 +16,9 @@ namespace PVZ
 		/// @brief Init() 系函数申请的、PVZ 本体的内存的基址，供部分函数使用。
 		/// @detail 000-100存放创建子弹的函数\n
 		///		100 - 200存放字符串或者PlantEffect的伪造植物对象\n
+		///		200 - 224存放 AsmInit() 为传送门创建设定的辅助代码\n
+		///		225 - 249存放随机数调用\n
 		///		300 - 400存放__autocollect_set\n
-		///		400 - 500存放__asm__Plant_memset\n
 		///		500 - 600存放Execute的同步代码\n
 		static int Variable;
 		/// @brief PVZ 进程句柄

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -1051,6 +1051,9 @@ namespace PVZ
 		PVZ::Projectile Shoot(MotionType::MotionType motiontype = MotionType::None, int targetid = -1, bool special = false);
 		//animPlayArg(APA_XXXXXX)
 		void SetAnimation(LPCSTR animName, byte animPlayArg, int imagespeed);
+		/// @brief 以指定帧频播放闲置动画。IZ 关卡中动画速率会设为 0 。
+		/// @param speed 指定的帧频
+		void PlayIdleAnim(float speed);
 		class MagnetItem
 		{
 			int BaseAddress;

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -228,6 +228,14 @@ namespace PVZ
 		}
 	public:
 		Board(int address) : Widget(address) {};
+
+		/// @brief 调整该类在 PVZ 中对象的大小。
+		/// @note 请在派生类中调用这个函数。
+		/// @note 调用该函数后，新生成的存档与原版存档不兼容，请注意清理。
+		/// @note 额外的空间未经初始化，使用前请设法初始化。
+		/// @param MemSize 更改后的大小。
+		static void SetMemSize(int NewSize);
+
 		PVZApp GetPVZApp();
 		/// @brief 场上僵尸数量
 		INT_READONLY_PROPERTY(ZombiesCount, __get_ZombiesCount, 0xA0);

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -259,6 +259,7 @@
     <ClInclude Include="Enums\StoreItem.hpp" />
     <ClInclude Include="Enums\ZombieAttackType.hpp" />
     <ClInclude Include="Events\BegTwistFailMoveEvent.hpp" />
+    <ClInclude Include="Events\BoardInitAfterEvent.hpp" />
     <ClInclude Include="Events\BoardKeyDownEvent.hpp" />
     <ClInclude Include="Events\BoardUpdateGameEvent.hpp" />
     <ClInclude Include="Events\CalcSunCostEvent.hpp" />

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -773,5 +773,8 @@
     <ClInclude Include="Events\ProjectileImageEvent.hpp">
       <Filter>头文件\Events\Projectile</Filter>
     </ClInclude>
+    <ClInclude Include="Events\BoardInitAfterEvent.hpp">
+      <Filter>头文件\Events\Board</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- `Plant` 类新增 `PlayIdleReanim()`，直接播放空闲动画。
- `Plant::SetMemSize()` 不再另行 `memset()`。
- 添加了 `pvzdll` 专用的 `Creator::Rand()`，调用 PVZ 本体的随机数生成器获取随机整数。
- 修复 `FloatDLLEventTemplate` 的崩溃漏洞。
- `PlantDamageZombieEvent::PZDamageInfo` 现在可以使用派生类。
- 添加 `Board::SetMemSize()`，用于扩展 Board 大小。
- 添加 `BoardInitAfterEvent`，用于处理 Board 初始化。
- 以下事件现在支持 int 参数构造：
  - `PlantDamageZombieEvent`
  - `ZombieInitAfterEvent`
  - `UpdateGameObjectsEvent`
  - `PlantInitAfterEvent`