### PR TITLE
ProjectileDamageZombieEvent 优化

### DIFF
--- a/pvzclass/Events/ProjectileDefEvent.hpp
+++ b/pvzclass/Events/ProjectileDefEvent.hpp
@@ -1,13 +1,20 @@
-#pragma once
+﻿#pragma once
 #include "DLLEvent.h"
 
 namespace PVZEvent
 {
+	enum ProjDmgType
+	{
+		DAMAGE_SINGULAR,
+		DAMAGE_SPLASH_PRIMARY,
+		DAMAGE_SPLASH_SECONDARY
+	};
+
 	class ProjectileDamageZombieEvent
 	{
 	private:
 		class DamagePart1 : public IntDLLEventTemplate<0x46E073, 7, 0, 0,
-			INT32_MIN, REG_EDX, false, CONST_VAL(0), REG_ESI, REG_EDI>
+			INT32_MIN, REG_EDX, false, CONST_VAL(0), CONST_VAL(DAMAGE_SINGULAR), REG_ESI, REG_EDI>
 		{
 		public:
 			DamagePart1(const char* str) : IntDLLEventTemplate() { Init(str); };
@@ -18,13 +25,19 @@ namespace PVZEvent
 			DamagePart2(const char* str)
 			{
 				int procAddress = PVZ::Memory::GetProcAddress(str);
-				hookAddress = 0x46ECB0;
-				rawlen = 7;
+				hookAddress = 0x46D468;
+				rawlen = 5;
 				BYTE code[] =
 				{
-					MOV_PTR_ESP_ADD_V_EUX(REG_EBP, 0x34),
-					PUSH(1),
-					PUSH_PTR_ESP_ADD_V(0x40),
+					PUSH_PTR_ESP_ADD_V(0x34),
+
+					CALC_PTR_ESP_ADD_V_EUX(CALC_CMP, REG_ESI, 0x40),
+					JNZ(4),
+					PUSH(DAMAGE_SPLASH_PRIMARY),
+					JMP(2),
+					PUSH(DAMAGE_SPLASH_SECONDARY),
+
+					PUSH_PTR_ESP_ADD_V(0x44),
 					PUSH_EDI,
 					INVOKE(procAddress),
 					ADD_ESP(0x0C),

--- a/pvzclass/Events/ProjectileDefEvent.hpp
+++ b/pvzclass/Events/ProjectileDefEvent.hpp
@@ -3,13 +3,20 @@
 
 namespace PVZEvent
 {
+	/// @brief 子弹对僵尸伤害类型
 	enum ProjDmgType
 	{
+		/// @brief 非溅射伤害
 		DAMAGE_SINGULAR,
+		/// @brief 溅射伤害的主目标
 		DAMAGE_SPLASH_PRIMARY,
+		/// @brief 溅射伤害的次级目标
 		DAMAGE_SPLASH_SECONDARY
 	};
 
+	/// @brief 子弹对僵尸造成伤害事件
+	/// @param 依次为：子弹基址、受伤僵尸基址、伤害类型、溅射僵尸次级目标数
+	/// @return 调整后的伤害。
 	class ProjectileDamageZombieEvent
 	{
 	private:
@@ -29,23 +36,21 @@ namespace PVZEvent
 				rawlen = 5;
 				BYTE code[] =
 				{
-					PUSH_PTR_ESP_ADD_V(0x34),
+					PUSH_PTR_ESP_ADD_V(0x38),
 
-					CALC_PTR_ESP_ADD_V_EUX(CALC_CMP, REG_ESI, 0x40),
+					CALC_PTR_ESP_ADD_V_EUX(CALC_CMP, REG_ESI, 0x44),
 					JNZ(4),
 					PUSH(DAMAGE_SPLASH_PRIMARY),
 					JMP(2),
 					PUSH(DAMAGE_SPLASH_SECONDARY),
 
-					PUSH_PTR_ESP_ADD_V(0x44),
+					PUSH_PTR_ESP_ADD_V(0x48),
 					PUSH_EDI,
 					INVOKE(procAddress),
 					ADD_ESP(0x0C),
 
-					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0x20),
 					POPAD,
-					MOV_EAX(0x46D3EE),
-					JMP_REG32(REG_EAX)
 				};
 				start(STRING(code));
 			}

--- a/pvzclass/Events/ProjectileDefEvent.hpp
+++ b/pvzclass/Events/ProjectileDefEvent.hpp
@@ -16,12 +16,12 @@ namespace PVZEvent
 
 	/// @brief 子弹对僵尸造成伤害事件
 	/// @param 依次为：子弹基址、受伤僵尸基址、伤害类型、溅射僵尸次级目标数
-	/// @return 调整后的伤害。
+	/// @return 调整后的伤害。非负值会被忽略。
 	class ProjectileDamageZombieEvent
 	{
 	private:
 		class DamagePart1 : public IntDLLEventTemplate<0x46E073, 7, 0, 0,
-			INT32_MIN, REG_EDX, false, CONST_VAL(0), CONST_VAL(DAMAGE_SINGULAR), REG_ESI, REG_EDI>
+			0, REG_EDX, false, CONST_VAL(0), CONST_VAL(DAMAGE_SINGULAR), REG_ESI, REG_EDI>
 		{
 		public:
 			DamagePart1(const char* str) : IntDLLEventTemplate() { Init(str); };
@@ -49,8 +49,9 @@ namespace PVZEvent
 					INVOKE(address),
 					ADD_ESP(0x0C),
 
+					TEST_EUX_EVX(REG_EAX, REG_EAX),
+					JS(4),
 					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0x20),
-					POPAD,
 				};
 				start(STRING(code));
 			}

--- a/pvzclass/Events/ProjectileDefEvent.hpp
+++ b/pvzclass/Events/ProjectileDefEvent.hpp
@@ -25,13 +25,13 @@ namespace PVZEvent
 		{
 		public:
 			DamagePart1(const char* str) : IntDLLEventTemplate() { Init(str); };
+			DamagePart1(int address) : IntDLLEventTemplate() { Init(address); };
 		};
 		class DamagePart2 : public DLLEvent
 		{
 		public: 
-			DamagePart2(const char* str)
+			DamagePart2(int address)
 			{
-				int procAddress = PVZ::Memory::GetProcAddress(str);
 				hookAddress = 0x46D468;
 				rawlen = 5;
 				BYTE code[] =
@@ -46,7 +46,7 @@ namespace PVZEvent
 
 					PUSH_PTR_ESP_ADD_V(0x48),
 					PUSH_EDI,
-					INVOKE(procAddress),
+					INVOKE(address),
 					ADD_ESP(0x0C),
 
 					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0x20),
@@ -54,6 +54,7 @@ namespace PVZEvent
 				};
 				start(STRING(code));
 			}
+			DamagePart2(const char* str) : DamagePart2(PVZ::Memory::GetProcAddress(str)) { };
 		};
 		DamagePart1* part1;
 		DamagePart2* part2;
@@ -63,6 +64,11 @@ namespace PVZEvent
 			const char* str = "onProjectileDamageZombie";
 			part1 = new DamagePart1(str);
 			part2 = new DamagePart2(str);
+		}
+		ProjectileDamageZombieEvent(int address)
+		{
+			part1 = new DamagePart1(address);
+			part2 = new DamagePart2(address);
 		}
 		void end()
 		{


### PR DESCRIPTION
- 现在 `ProjectileDamageZombieEvent`  可以调整溅射次级目标的伤害，并且知道溅射次级目标的总数。