### PR TITLE
事件更新与漏洞修复

### DIFF
--- a/pvzclass/Events/PlantProduceEvent.hpp
+++ b/pvzclass/Events/PlantProduceEvent.hpp
@@ -1,31 +1,13 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Ö²Îï²ú³öÎïÆ·ÊÂ¼ş¡£
-/// @param ´¥·¢ÊÂ¼şµÄÖ²Îï
-/// @return ÊÇ·ñ¼ÌĞø²ú³öÔ­°æÎïÆ·¡£
-class PlantProduceEvent : public DLLEvent
+/// @brief æ¤ç‰©äº§å‡ºç‰©å“äº‹ä»¶ã€‚
+/// @param è§¦å‘äº‹ä»¶çš„æ¤ç‰©
+/// @return æ˜¯å¦ç»§ç»­äº§å‡ºåŸç‰ˆç‰©å“ã€‚
+class PlantProduceEvent : public BoolDLLEventTemplate<0x45FAA7, 6, 0x45FB64, REG_EDI>
 {
 public:
-	PlantProduceEvent();
+	PlantProduceEvent(const char* str) : BoolDLLEventTemplate() { Init(str); };
+	PlantProduceEvent(int address) : BoolDLLEventTemplate() { Init(address); };
+	PlantProduceEvent() : PlantProduceEvent("onPlantProduce") {};
 };
-
-PlantProduceEvent::PlantProduceEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantProduce");
-	hookAddress = 0x45FAA7;
-	rawlen = 6;
-	BYTE code[] =
-	{
-		PUSH_EDI,
-		INVOKE(procAddress),
-		ADD_ESP(4),
-
-		TEST_AL_AL,
-		JNZ(8),
-		POPAD,
-		MOV_EAX(0x45FB64),
-		JMP_REG32(REG_EAX)
-	};
-	start(STRING(code));
-}

--- a/pvzclass/Events/PlantReloadEvent.h
+++ b/pvzclass/Events/PlantReloadEvent.h
@@ -1,23 +1,21 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Ö²ÎïÖØĞÂ×°ÌîÊÂ¼ş
-// ²ÎÊı£º´¥·¢ÊÂ¼şµÄÖ²Îï£¬ÉúĞ§µ¹¼ÆÊ±
-// ·µ»ØÖµ£ºĞŞ¸ÄºóµÄµ¹¼ÆÊ±
-// ¼àÌıÆ÷Ö®¼ä´®ÁªĞŞ¸Ä
-// ×¢£ºÖ²ÎïÃ¿¸ôÒ»¶ÎÊ±¼ä¾ÍÖØĞÂ×°Ìî£¬´ËÊ±Èç¹û·¢ÏÖ½©Ê¬ÔòÉä»÷
-// ÉúĞ§µ¹¼ÆÊ±Ä¬ÈÏÎªÉúĞ§¼ä¸ô¼õÈ¥Ò»¸ö[0,14]µÄËæ»úÊı
+/// @brief æ¤ç‰©é‡æ–°è£…å¡«äº‹ä»¶
+/// @param è§¦å‘äº‹ä»¶çš„æ¤ç‰©ï¼Œç”Ÿæ•ˆå€’è®¡æ—¶
+/// @return ä¿®æ”¹åçš„å€’è®¡æ—¶
+/// @note æ¤ç‰©æ¯éš”ä¸€æ®µæ—¶é—´å°±é‡æ–°è£…å¡«ï¼Œæ­¤æ—¶å¦‚æœå‘ç°åƒµå°¸åˆ™å°„å‡»\n
+/// ç”Ÿæ•ˆå€’è®¡æ—¶é»˜è®¤ä¸ºç”Ÿæ•ˆé—´éš”å‡å»ä¸€ä¸ª[0,14]çš„éšæœºæ•°
 class PlantReloadEvent : public DLLEvent
 {
 public:
-	PlantReloadEvent();
+	PlantReloadEvent() : PlantReloadEvent("onPlantReload") {};
+	PlantReloadEvent(const char* str) : PlantReloadEvent(PVZ::Memory::GetProcAddress(str)) {};
+	PlantReloadEvent(int address)
+	{
+		hookAddress = 0x45F8C4;
+		rawlen = 6;
+		BYTE code[] = { PUSH_ECX, PUSH_ESI, INVOKE(address), ADD_ESP(8), MOV_PTR_ESP_ADD_V_EUX(0, 24) };
+		start(STRING(code));
+	}
 };
-
-PlantReloadEvent::PlantReloadEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantReload");
-	hookAddress = 0x45F8C4;
-	rawlen = 6;
-	BYTE code[] = { PUSH_ECX, PUSH_ESI, INVOKE(procAddress), ADD_ESP(8), MOV_PTR_ESP_ADD_V_EUX(0, 24) };
-	start(STRING(code));
-}

--- a/pvzclass/Events/PlantShootEvent.h
+++ b/pvzclass/Events/PlantShootEvent.h
@@ -1,20 +1,12 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Ö²ÎïÉä»÷ÊÂ¼ş
-// ²ÎÊı£º´¥·¢ÊÂ¼şµÄÖ²Îï
-// ÎŞ·µ»ØÖµ
-class PlantShootEvent : public DLLEvent
+/// @brief æ¤ç‰©å°„å‡»äº‹ä»¶
+/// @param è§¦å‘äº‹ä»¶çš„æ¤ç‰©
+class PlantShootEvent : public DLLEventTemplate<0x466E0D, 6, REG_EBP>
 {
 public:
-	PlantShootEvent();
+	PlantShootEvent(const char* str) : DLLEventTemplate() { Init(str); };
+	PlantShootEvent(int address) : DLLEventTemplate() { Init(address); };
+	PlantShootEvent() : PlantShootEvent("onPlantShoot") {};
 };
-
-PlantShootEvent::PlantShootEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantShoot");
-	hookAddress = 0x466E0D;
-	rawlen = 6;
-	BYTE code[] = { PUSH_EBP, INVOKE(procAddress), ADD_ESP(4) };
-	start(STRING(code));
-}

--- a/pvzclass/Events/PlantShoveledEvent.hpp
+++ b/pvzclass/Events/PlantShoveledEvent.hpp
@@ -1,32 +1,31 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Ö²Îï±»²ù³ıÊÂ¼ş¡£
-/// @param ´¥·¢ÊÂ¼şµÄÖ²Îï
-/// @return Êµ¼Ê±»²ú³öµÄÖ²ÎïµÄ»ùÖ·¡£ÈôÎª¿ÕÖ¸Õë£¬Ôò¸ÃÊÂ¼ş±»È¡Ïû¡£
+/// @brief æ¤ç‰©è¢«é“²é™¤äº‹ä»¶ã€‚
+/// @param è§¦å‘äº‹ä»¶çš„æ¤ç‰©
+/// @return å®é™…è¢«äº§å‡ºçš„æ¤ç‰©çš„åŸºå€ã€‚è‹¥ä¸ºç©ºæŒ‡é’ˆï¼Œåˆ™è¯¥äº‹ä»¶è¢«å–æ¶ˆã€‚
 class PlantShoveledEvent : public DLLEvent
 {
 public:
-	PlantShoveledEvent();
-};
-
-PlantShoveledEvent::PlantShoveledEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantShoveled");
-	hookAddress = 0x4111C8;
-	rawlen = 6;
-	BYTE code[] =
+	PlantShoveledEvent() : PlantShoveledEvent("onPlantShoveled") {};
+	PlantShoveledEvent(const char* str) : PlantShoveledEvent(PVZ::Memory::GetProcAddress(str)) {};
+	PlantShoveledEvent(int address)
 	{
-		PUSH_EBP,
-		INVOKE(procAddress),
-		MOV_EUX_EVX(REG_EBP, REG_EAX),
-		ADD_ESP(4),
+		hookAddress = 0x4111C8;
+		rawlen = 6;
+		BYTE code[] =
+		{
+			PUSH_EBP,
+			INVOKE(procAddress),
+			MOV_EUX_EVX(REG_EBP, REG_EAX),
+			ADD_ESP(4),
 
-		TEST_EUX_EVX(REG_EBP, REG_EBP),
-		JNZ(8),
-		POPAD,
-		MOV_EAX(0x411268),
-		JMP_REG32(REG_EAX)
-	};
-	start(STRING(code));
-}
+			TEST_EUX_EVX(REG_EBP, REG_EBP),
+			JNZ(8),
+			POPAD,
+			MOV_EAX(0x411268),
+			JMP_REG32(REG_EAX)
+		};
+		start(STRING(code));
+	}
+};

--- a/pvzclass/Events/PlantStolenEvent.hpp
+++ b/pvzclass/Events/PlantStolenEvent.hpp
@@ -1,25 +1,12 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Ö²Îï±»Íµ×ßÊÂ¼ş¡£
-// ÎŞ·µ»ØÖµ
-/// @param ÒÀ´ÎÎª£º´¥·¢ÊÂ¼şµÄÖ²Îï¡£
-class PlantStolenEvent : public DLLEvent
+/// @brief æ¤ç‰©è¢«å·èµ°äº‹ä»¶ã€‚
+/// @param è§¦å‘äº‹ä»¶çš„æ¤ç‰©ã€‚
+class PlantStolenEvent : public DLLEventTemplate<0x5304B6, 7, REG_EAX>
 {
 public:
-	PlantStolenEvent();
+	PlantStolenEvent(const char* str) : DLLEventTemplate() { Init(str); };
+	PlantStolenEvent(int address) : DLLEventTemplate() { Init(address); };
+	PlantStolenEvent() : PlantStolenEvent("onPlantStolen") {};
 };
-
-PlantStolenEvent::PlantStolenEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantStolen");
-	hookAddress = 0x5304B6;
-	rawlen = 7;
-	BYTE code[] =
-	{
-		PUSH_EAX,
-		INVOKE(procAddress),
-		ADD_ESP(4),
-	};
-	start(STRING(code));
-}

--- a/pvzclass/Events/PlantUpdateAbilityEvent.hpp
+++ b/pvzclass/Events/PlantUpdateAbilityEvent.hpp
@@ -1,38 +1,36 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Ö²ÎïÌØĞÔ¸üĞÂÊÂ¼ş¡£
-// Ê±»úÉÏÏÈÓÚ±£ÁäÇòÌØĞÔ¡£
-/// @param ´¥·¢ÊÂ¼şµÄÖ²Îï¡£
-/// @return ÊÇ·ñ½áËã´ó²¿·ÖÔ­°æÌØĞÔ¡£ÈôÎª¡°·ñ¡±£¬ÔòÖ»½áËãÉäÊÖºÍÒ»´ÎĞÔÖ²ÎïµÄÌØĞÔ¡£
+/// @brief æ¤ç‰©ç‰¹æ€§æ›´æ–°äº‹ä»¶ã€‚
+/// @note æ—¶æœºä¸Šå…ˆäºä¿é¾„çƒç‰¹æ€§ã€‚
+/// @param è§¦å‘äº‹ä»¶çš„æ¤ç‰©ã€‚
+/// @return æ˜¯å¦ç»“ç®—å¤§éƒ¨åˆ†åŸç‰ˆç‰¹æ€§ã€‚è‹¥ä¸ºâ€œå¦â€ï¼Œåˆ™åªç»“ç®—å°„æ‰‹å’Œä¸€æ¬¡æ€§æ¤ç‰©çš„ç‰¹æ€§ã€‚
 class PlantUpdateAbilityEvent : public DLLEvent
 {
 public:
-	PlantUpdateAbilityEvent();
-};
-
-PlantUpdateAbilityEvent::PlantUpdateAbilityEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onPlantUpdateAbility");
-	hookAddress = 0x463254;
-	rawlen = 5;
-	BYTE code[] =
+	PlantUpdateAbilityEvent() : PlantUpdateAbilityEvent("onPlantUpdateAbility") {};
+	PlantUpdateAbilityEvent(const char* str) : PlantUpdateAbilityEvent(PVZ::Memory::GetProcAddress(str)) {};
+	PlantUpdateAbilityEvent(int address)
 	{
-		PUSH_EDI,
-		INVOKE(procAddress),
-		ADD_ESP(4),
-		TEST_AL_AL,
-		JNZ(8),
+		hookAddress = 0x463254;
+		rawlen = 5;
+		BYTE code[] =
+		{
+			PUSH_EDI,
+			INVOKE(address),
+			ADD_ESP(4),
+			TEST_AL_AL,
+			JNZ(8),
 
-		POPAD,
-		MOV_ECX(0x4633EE),
-		JMP_REG32(REG_ECX),
+			POPAD,
+			MOV_ECX(0x4633EE),
+			JMP_REG32(REG_ECX),
 
-		POPAD,
-		INVOKE(0x453840),
-		MOV_ECX(0x463259),
-		JMP_REG32(REG_ECX),
-	};
-	start(STRING(code));
-}
-#pragma once
+			POPAD,
+			INVOKE(0x453840),
+			MOV_ECX(0x463259),
+			JMP_REG32(REG_ECX),
+		};
+		start(STRING(code));
+	}
+};

--- a/pvzclass/Events/PlantUpdateEvent.hpp
+++ b/pvzclass/Events/PlantUpdateEvent.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "DLLEvent.h"
 
 namespace PVZEvent
@@ -6,29 +6,11 @@ namespace PVZEvent
 	/// @brief 植物更新事件。
 	/// @param 触发事件的植物。
 	/// @return 是否考虑进行此次更新。
-	class PlantUpdateEvent : public DLLEvent
+	class PlantUpdateEvent : public BoolDLLEventTemplate<0x463E43, 6, 0x463EE8, REG_EBX>
 	{
 	public:
-		PlantUpdateEvent();
+		PlantUpdateEvent(const char* str) : BoolDLLEventTemplate() { Init(str); };
+		PlantUpdateEvent(int address) : BoolDLLEventTemplate() { Init(address); };
+		PlantUpdateEvent() : PlantUpdateEvent("onPlantStolen") {};
 	};
-
-	PlantUpdateEvent::PlantUpdateEvent()
-	{
-		int procAddress = PVZ::Memory::GetProcAddress("onPlantUpdate");
-		hookAddress = 0x463E43;
-		rawlen = 6;
-		BYTE code[] =
-		{
-			PUSH_EBX,
-			INVOKE(procAddress),
-			ADD_ESP(4),
-
-			TEST_AL_AL,
-			JNZ(8),
-			POPAD,
-			MOV_ECX(0x463EE8),
-			JMP_REG32(REG_ECX)
-		};
-		start(STRING(code));
-	}
 }

--- a/pvzclass/Events/ProjectileDefEvent.hpp
+++ b/pvzclass/Events/ProjectileDefEvent.hpp
@@ -45,7 +45,7 @@ namespace PVZEvent
 					JMP(2),
 					PUSH(DAMAGE_SPLASH_SECONDARY),
 
-					PUSH_PTR_ESP_ADD_V(0x4C),
+					PUSH_ESI,
 					PUSH_EDI,
 					INVOKE(address),
 					ADD_ESP(0x14),


### PR DESCRIPTION
- 修复 `ProjectileDamageZombieEvent` 的参数不正确的漏洞。
- `Plant` 系列事件现在具有新的构造函数和完整的 Doxygen 注释。