### PR TITLE
剩余事件的构造函数优化

### DIFF
--- a/pvzclass/Events/DialogButtonDepressEvent.h
+++ b/pvzclass/Events/DialogButtonDepressEvent.h
@@ -1,26 +1,25 @@
 #pragma once
 #include "DLLEvent.h"
 
-// ¶Ô»°ÖĞµÄ°´Å¥µ¯ÆğÊÂ¼ş£¬¶ÔÓ¦µÄÊÇÍæ¼Òµã»÷°´Å¥²¢ËÉ¿ªµÄ²Ù×÷
-// buttonID£º1000´ú±íÈ·ÈÏ£¬1001´ú±íÈ¡Ïû
-// dialogID£º¶Ô»°¿òµÄid
-// Ô­±¾ÓÎÏ·ÖĞµÄ¶Ô»°¿òÒ²»á´¥·¢Õâ¸öÊÂ¼ş£¬ĞëÈ·±£dialogIDÎ¨Ò»
-// Èç¹û·µ»ØÖµ·Ç0£¬ÔòÈ¡ÏûÔ­±¾ÓÎÏ·µÄºóĞø´¦Àí
+/// @brief å¯¹è¯ä¸­çš„æŒ‰é’®å¼¹èµ·äº‹ä»¶ï¼Œå¯¹åº”çš„æ˜¯ç©å®¶ç‚¹å‡»æŒ‰é’®å¹¶æ¾å¼€çš„æ“ä½œ
+/// @param buttonID 1000ä»£è¡¨ç¡®è®¤ï¼Œ1001ä»£è¡¨å–æ¶ˆ\n
+/// dialogID å¯¹è¯æ¡†çš„id
+/// @note åŸæœ¬æ¸¸æˆä¸­çš„å¯¹è¯æ¡†ä¹Ÿä¼šè§¦å‘è¿™ä¸ªäº‹ä»¶ï¼Œé¡»ç¡®ä¿dialogIDå”¯ä¸€
+/// @return å¦‚æœè¿”å›å€¼é0ï¼Œåˆ™å–æ¶ˆåŸæœ¬æ¸¸æˆçš„åç»­å¤„ç†
 class DialogButtonDepressEvent : public DLLEvent
 {
 public:
-	DialogButtonDepressEvent();
-};
-
-DialogButtonDepressEvent::DialogButtonDepressEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onDialogButtonDepress");
-	hookAddress = 0x5464A0;
-	rawlen = 9;
-	BYTE code[] =
+	DialogButtonDepressEvent() : DialogButtonDepressEvent("onDialogButtonDepress") {};
+	DialogButtonDepressEvent(const char* str) : DialogButtonDepressEvent(PVZ::Memory::GetProcAddress(str)) {};
+	DialogButtonDepressEvent(int address)
 	{
-		PUSH_PTR_ESP_ADD_V(36), PUSH_PTR_ESP_ADD_V(44), INVOKE(procAddress), ADD_ESP(8),
-		TEST_AL_AL, JE(4), POPAD, RETN(8)
-	};
-	start(STRING(code));
-}
+		hookAddress = 0x5464A0;
+		rawlen = 9;
+		BYTE code[] =
+		{
+			PUSH_PTR_ESP_ADD_V(36), PUSH_PTR_ESP_ADD_V(44), INVOKE(address), ADD_ESP(8),
+			TEST_AL_AL, JE(4), POPAD, RETN(8)
+		};
+		start(STRING(code));
+	}
+};

--- a/pvzclass/Events/DrawPlantReanimEvent.h
+++ b/pvzclass/Events/DrawPlantReanimEvent.h
@@ -1,27 +1,26 @@
 #pragma once
 #include "DLLEvent.h"
 
-// »æÖÆÖ²Îï¶¯»­ÊÂ¼ş
-// ²ÎÊı£º»æÖÆµÄÖ²ÎïºÍ¶ÔÓ¦µÄ¶¯»­
-// ÊÂ¼ş´¥·¢ÔÚÑÕÉ«¼ÆËãÖ®ºóºÍ»æÖÆ·¢ÉúÖ®Ç°
+/// @brief ç»˜åˆ¶æ¤ç‰©åŠ¨ç”»äº‹ä»¶
+/// @param ç»˜åˆ¶çš„æ¤ç‰©å’Œå¯¹åº”çš„åŠ¨ç”»
+// äº‹ä»¶è§¦å‘åœ¨é¢œè‰²è®¡ç®—ä¹‹åå’Œç»˜åˆ¶å‘ç”Ÿä¹‹å‰
 class DrawPlantReanimEvent : public DLLEvent
 {
 public:
-	DrawPlantReanimEvent();
+	DrawPlantReanimEvent() : DrawPlantReanimEvent("onDrawPlantReanim") {};
+	DrawPlantReanimEvent(const char* str) : DrawPlantReanimEvent(PVZ::Memory::GetProcAddress(str)) {};
+	DrawPlantReanimEvent(int address)
+	{
+		PVZ::Memory::WriteMemory<BYTE>(0x4638C4, 0xEB);
+		PVZ::Memory::WriteMemory<BYTE>(0x4638C5, 0x15);
+		PVZ::Memory::WriteMemory<BYTE>(0x4638C6, NOP);
+		PVZ::Memory::WriteMemory<BYTE>(0x4638C7, NOP);
+		PVZ::Memory::WriteMemory<BYTE>(0x4638C8, NOP);
+		hookAddress = 0x4638DB;
+		rawlen = 5;
+		BYTE code[] = { PUSH_EBX, PUSH_PTR_ESP_ADD_V(0x2C), INVOKE(address), ADD_ESP(8),
+			POPAD, INVOKE(0x473AE0), JMP(6)
+		};
+		start(STRING(code));
+	}
 };
-
-DrawPlantReanimEvent::DrawPlantReanimEvent()
-{
-	PVZ::Memory::WriteMemory<BYTE>(0x4638C4, 0xEB);
-	PVZ::Memory::WriteMemory<BYTE>(0x4638C5, 0x15);
-	PVZ::Memory::WriteMemory<BYTE>(0x4638C6, NOP);
-	PVZ::Memory::WriteMemory<BYTE>(0x4638C7, NOP);
-	PVZ::Memory::WriteMemory<BYTE>(0x4638C8, NOP);
-	int procAddress = PVZ::Memory::GetProcAddress("onDrawPlantReanim");
-	hookAddress = 0x4638DB;
-	rawlen = 5;
-	BYTE code[] = { PUSH_EBX, PUSH_PTR_ESP_ADD_V(0x2C), INVOKE(procAddress), ADD_ESP(8),
-		POPAD, INVOKE(0x473AE0), JMP(6)
-	};
-	start(STRING(code));
-}

--- a/pvzclass/Events/DrawUITopEvent.h
+++ b/pvzclass/Events/DrawUITopEvent.h
@@ -1,20 +1,18 @@
 #pragma once
 #include "DLLEvent.h"
 
-// »æÖÆ¶¥²ãUIÊÂ¼ş
-// ÎŞ²ÎÊıÓë·µ»ØÖµ
-// ÇëÓëDraw.hÅäºÏÊ¹ÓÃ
+// ç»˜åˆ¶é¡¶å±‚UIäº‹ä»¶
+// æ— å‚æ•°ä¸è¿”å›å€¼
+// è¯·ä¸Draw.hé…åˆä½¿ç”¨
 class DrawUITopEvent : public DLLEvent
 {
 public:
-	DrawUITopEvent();
+	DrawUITopEvent()
+	{
+		int procAddress = PVZ::Memory::GetProcAddress("onDrawUITop");
+		hookAddress = 0x41ACDF;
+		rawlen = 5;
+		BYTE code[] = { PUSH_PTR_ESP_ADD_V(40), INVOKE(procAddress), ADD_ESP(4) };
+		start(STRING(code));
+	}
 };
-
-DrawUITopEvent::DrawUITopEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onDrawUITop");
-	hookAddress = 0x41ACDF;
-	rawlen = 5;
-	BYTE code[] = { PUSH_PTR_ESP_ADD_V(40), INVOKE(procAddress), ADD_ESP(4) };
-	start(STRING(code));
-}

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -25,7 +25,6 @@
 #include "ProjectileHitZombieEvent.h"
 #include "ProjectileRemoveEvent.h"
 #include "PuzzlePhaseCompleteEvent.hpp"
-#include "SeedCardClickEvent.h"
 #include "UpdateAppEvent.h"
 #include "UpdateGameObjectsEvent.h"
 #include "ZombieBlastEvent.h"

--- a/pvzclass/Events/PlantShoveledEvent.hpp
+++ b/pvzclass/Events/PlantShoveledEvent.hpp
@@ -16,7 +16,7 @@ public:
 		BYTE code[] =
 		{
 			PUSH_EBP,
-			INVOKE(procAddress),
+			INVOKE(address),
 			MOV_EUX_EVX(REG_EBP, REG_EAX),
 			ADD_ESP(4),
 

--- a/pvzclass/Events/ZombieUpdateActionEvent.hpp
+++ b/pvzclass/Events/ZombieUpdateActionEvent.hpp
@@ -1,21 +1,13 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Zombie ÐÐÎª¶¯×÷µÄ¸üÐÂ¡£
-// Ê±»úÉÏÏÈÓÚÔ­°æµÄ¸üÐÂ¡£
-// ²ÎÊý£º¸üÐÂµÄ Zombie
-// ÎÞ·µ»ØÖµ
-class ZombieUpdateActionEvent : public DLLEvent
+/// @brief Zombie è¡Œä¸ºåŠ¨ä½œçš„æ›´æ–°ã€‚
+/// @note æ—¶æœºä¸Šå…ˆäºŽåŽŸç‰ˆçš„æ›´æ–°ã€‚
+/// @param æ›´æ–°çš„ Zombie
+class ZombieUpdateActionEvent : public DLLEventTemplate<0x52B112, 6, REG_EAX>
 {
 public:
-	ZombieUpdateActionEvent();
+	ZombieUpdateActionEvent() : DLLEventTemplate() { Init("onZombieUpdateAction"); };
+	ZombieUpdateActionEvent(const char* str) : DLLEventTemplate() { Init(str); };
+	ZombieUpdateActionEvent(int address) : DLLEventTemplate() { Init(address); };
 };
-
-ZombieUpdateActionEvent::ZombieUpdateActionEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onZombieUpdateAction");
-	hookAddress = 0x52B112;
-	rawlen = 6;
-	BYTE code[] = { PUSH_EAX, INVOKE(procAddress), ADD_ESP(4) };
-	start(STRING(code));
-}

--- a/pvzclass/Events/ZombieUpdatePlayingEvent.hpp
+++ b/pvzclass/Events/ZombieUpdatePlayingEvent.hpp
@@ -1,21 +1,13 @@
 #pragma once
 #include "DLLEvent.h"
 
-// Zombie ½ÇÉ«µÄ¸üĞÂ£¬±»¶³½á¡¢»ÆÓÍ¶¨ÉíÊ±Ò²»á½áËã¡£
-// Ê±»úÉÏÏÈÓÚÔ­°æµÄ¸üĞÂ¡£
-// ²ÎÊı£º¸üĞÂµÄ Zombie
-// ÎŞ·µ»ØÖµ
-class ZombieUpdatePlayingEvent : public DLLEvent
+/// @brief Zombie è§’è‰²çš„æ›´æ–°ï¼Œè¢«å†»ç»“ã€é»„æ²¹å®šèº«æ—¶ä¹Ÿä¼šç»“ç®—ã€‚
+/// @note æ—¶æœºä¸Šå…ˆäºåŸç‰ˆçš„æ›´æ–°ã€‚
+/// @param æ›´æ–°çš„ Zombie
+class ZombieUpdatePlayingEvent : public DLLEventTemplate<0x52B340, 6, REG_EDI>
 {
 public:
-	ZombieUpdatePlayingEvent();
+	ZombieUpdatePlayingEvent() : DLLEventTemplate() { Init("onZombieUpdatePlaying"); };
+	ZombieUpdatePlayingEvent(const char* str) : DLLEventTemplate() { Init(str); };
+	ZombieUpdatePlayingEvent(int address) : DLLEventTemplate() { Init(address); };
 };
-
-ZombieUpdatePlayingEvent::ZombieUpdatePlayingEvent()
-{
-	int procAddress = PVZ::Memory::GetProcAddress("onZombieUpdatePlaying");
-	hookAddress = 0x52B340;
-	rawlen = 6;
-	BYTE code[] = { PUSH_EDI, INVOKE(procAddress), ADD_ESP(4) };
-	start(STRING(code));
-}


### PR DESCRIPTION
- 除了 `DrawUITopEvent` 仅将构造函数改为内联外，所有事件现在都具有 doxygen 注释和新的构造函数。
- 移除了 `Events.h` 中的 `SeedCardClickEvent.h`。
- 修复 `PlantShoveledEvent` 编译错误的漏洞。