### PR TITLE
C++17，DLLEventTemplate 优化，其他调整。

### DIFF
--- a/pvzclass/Const.h
+++ b/pvzclass/Const.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "PVZ.h"
 #include "Extensions.h"
 
@@ -114,7 +114,7 @@ namespace Const
 	/// @return 该关卡的初始场景类型。
 	inline SceneType::SceneType GetLevelScene(PVZLevel::PVZLevel mode)
 	{
-		byte num = MEMREAD_BYTE(0x40AAC0) - 1;
+		byte num = MEMREAD_BYTE(0x40AAC0 + mode) - 1;
 		switch (num)
 		{
 		case 5:

--- a/pvzclass/Creators.cpp
+++ b/pvzclass/Creators.cpp
@@ -1,4 +1,4 @@
-﻿#include "Creators.h"
+#include "Creators.h"
 #include "Classes.hpp"
 #include <iostream>
 
@@ -285,7 +285,9 @@ PVZ::Crater Creator::CreateCrater(int row, int column, int duration)
 	SETARG(__asm__CreateCrater, 6) = row;
 	__asm__CreateCrater[11] = column;
 	SETARG(__asm__CreateCrater, 26) = PVZ::Memory::Variable;;
-	return PVZ::Crater(PVZ::Memory::Execute(STRING(__asm__CreateCrater)));
+	auto crater = PVZ::Crater(PVZ::Memory::Execute(STRING(__asm__CreateCrater)));
+	crater.DisappearCountdown = duration;
+	return crater;
 }
 
 byte __asm__CreateLadder[31]

--- a/pvzclass/Events/DLLEvent.h
+++ b/pvzclass/Events/DLLEvent.h
@@ -44,20 +44,63 @@ private:
 template<DWORD _Hook_Address, uint8_t _Raw_Len, DWORD ...Params>
 class DLLEventTemplate : public DLLEvent
 {
+private:	
+	template<DWORD param>
+	static constexpr size_t param_size()
+	{
+		if constexpr (param < MEM_ESP_ADD_MASK)
+			return 1;
+		else if constexpr (param < CONST_VAL_MASK)
+			return 4;
+		else
+			return 5;
+	}
+	static constexpr size_t calculate_total_size()
+	{
+		size_t total = 0;
+		((total += param_size<Params>()), ...);
+		return total;
+	}
+	static constexpr auto build_base_bytes() {
+		constexpr size_t total_size = calculate_total_size();
+		std::array<uint8_t, total_size> bytes{};
+		size_t offset = 0;
+
+		// 使用 lambda 处理每个参数
+		auto process = [&](auto param)
+		{
+			if (param < MEM_ESP_ADD_MASK)
+				bytes[offset++] = 0x50 | (param & 0x7);
+			else if (param < CONST_VAL_MASK)
+			{
+				bytes[offset++] = 0xFF;
+				bytes[offset++] = 0x74;
+				bytes[offset++] = 0x24;
+				bytes[offset++] = static_cast<uint8_t>(param);
+			}
+			else 
+			{
+				DWORD value = param - CONST_VAL_MASK;
+				bytes[offset++] = 0x68;
+				bytes[offset++] = static_cast<uint8_t>(value & 0xFF);
+				bytes[offset++] = static_cast<uint8_t>((value >> 8) & 0xFF);
+				bytes[offset++] = static_cast<uint8_t>((value >> 16) & 0xFF);
+				bytes[offset++] = static_cast<uint8_t>((value >> 24) & 0xFF);
+			}
+		};
+
+		// 展开参数包
+		(process(Params), ...);
+
+		return bytes;
+	}
+	static constexpr auto compiled_base_bytes = build_base_bytes();
 protected:
 	void Init(int address)
 	{
 		hookAddress = _Hook_Address;
 		rawlen = _Raw_Len;
-		AsmBuilder builder = AsmBuilder(128);
-
-		for (int i = 0, sz = this->regs.size(); i < sz; i++)
-			if (this->regs[i] < MEM_ESP_ADD_MASK)
-				builder.push_reg((uint8_t)this->regs[i]);
-			else if (this->regs[i] < CONST_VAL_MASK)
-				builder.push_m32_esp_imm8((uint8_t)this->regs[i]);
-			else
-				builder.push_imm32(this->regs[i] - CONST_VAL_MASK);
+		AsmBuilder builder = AsmBuilder(128).add_bytes(compiled_base_bytes.data(), calculate_total_size());
 
 		builder.invoke(address).add_reg_imm(REG_ESP, this->regs.size() << 2);
 		this->InitExtra(builder);

--- a/pvzclass/Events/Events.h
+++ b/pvzclass/Events/Events.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "BoardUpdateGameEvent.hpp"
 #include "CoinCollectEvent.h"
 #include "CoinCreateEvent.h"
@@ -25,7 +25,6 @@
 #include "ProjectileHitZombieEvent.h"
 #include "ProjectileRemoveEvent.h"
 #include "PuzzlePhaseCompleteEvent.hpp"
-#include "SeedCardClickEvent.h"
 #include "UpdateAppEvent.h"
 #include "UpdateGameObjectsEvent.h"
 #include "ZombieBlastEvent.h"

--- a/pvzclass/Events/PlantShoveledEvent.hpp
+++ b/pvzclass/Events/PlantShoveledEvent.hpp
@@ -16,7 +16,7 @@ public:
 		BYTE code[] =
 		{
 			PUSH_EBP,
-			INVOKE(procAddress),
+			INVOKE(address),
 			MOV_EUX_EVX(REG_EBP, REG_EAX),
 			ADD_ESP(4),
 

--- a/pvzclass/Injectors.h
+++ b/pvzclass/Injectors.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "PVZ.h"
 
 /// @brief 代码注入类，可以注入 byte 数组形式的汇编码
@@ -32,7 +32,7 @@ public:
 			RET
 		};
 		PVZ::Memory::WriteArray<byte>(OriPTR, STRING(jmpout));
-		for (register int i = 0, tmpl = OriLen - 6; i < tmpl; i++)
+		for (int i = 0, tmpl = OriLen - 6; i < tmpl; i++)
 			PVZ::Memory::WriteMemory<byte>(OriPTR + i + 6, NOP);
 
 		PVZ::Memory::WriteArray<byte>(InjectPos, ASMCode, CodeLen);

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -94,6 +94,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PreprocessToFile>false</PreprocessToFile>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -110,6 +111,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -128,6 +130,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,6 +159,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/pvzdll/pvzdll.vcxproj
+++ b/pvzdll/pvzdll.vcxproj
@@ -53,6 +53,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -72,6 +73,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/pvzmain/pvzmain.vcxproj
+++ b/pvzmain/pvzmain.vcxproj
@@ -77,6 +77,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -94,6 +95,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,6 +113,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -128,6 +131,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
- 修复 `Const::GetLevelScene()` 无法正确返回结果的漏洞。
- 修复 `Creator::CreateCrater()` 实际上无法设置消失倒计时的漏洞。
- PVZClass 全面改用 C++17。
- 现在 DLLEventTemplate 加载参数部分的代码可被编译器优化。